### PR TITLE
fix(seo): make / → /en redirect permanent (301)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
   "cleanUrls": true,
   "ignoreCommand": "git diff --quiet HEAD^ HEAD -- app/ components/ content/ pages/ public/ scripts/ styles/ theme.config.tsx next.config.mjs proxy.ts package.json vercel.json",
   "redirects": [
-    { "source": "/", "destination": "/en", "permanent": false },
+    { "source": "/", "destination": "/en", "permanent": true },
     { "source": "/streaming", "destination": "/en/streaming/overview", "permanent": true },
     { "source": "/streaming/overview", "destination": "/en/streaming/overview", "permanent": true },
     { "source": "/streaming/:path*", "destination": "/en/streaming/:path*", "permanent": true },


### PR DESCRIPTION
## Summary

- The root redirect `{ "source": "/", "destination": "/en", "permanent": false }` was the only `permanent: false` entry in `vercel.json`; every other redirect uses 301.
- Changed to `"permanent": true` so Vercel emits a 308 permanent redirect instead of a 307 temporary one.

## Root cause

GSC URL Inspection on `docs.sharpapi.io/en` (via `sc-domain:sharpapi.io` property):

```
coverageState:   Duplicate, Google chose different canonical than user
userCanonical:   https://docs.sharpapi.io/en
googleCanonical: https://docs.sharpapi.io/
```

Both `/` and `/en` serve identical content. The HTML canonical on both points to `/en`, but Google kept `/` in the index because 307 signals "URL will move back" — it does not consolidate the two URLs. 308/301 does.

## Test plan

- [x] `curl -sI https://docs.sharpapi.io/` today returns 307 → `/en`
- [ ] After deploy: same curl returns 308
- [ ] After deploy: GSC → Pages → "Duplicate, Google chose different canonical" → Validate Fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)