### PR TITLE
docs(api)!: drop game_state from EV/arb/low-hold reference

### DIFF
--- a/content/en/api-reference/opportunities-arbitrage.mdx
+++ b/content/en/api-reference/opportunities-arbitrage.mdx
@@ -34,6 +34,10 @@ Requires API key. **Hobby tier or higher required.** Your account must have the 
 **Profit cap:** Opportunities with profit above 10% are automatically filtered out. These are almost always phantom arbs caused by stale or suspended odds rather than real opportunities.
 </Callout>
 
+<Callout type="warning">
+**Breaking change:** The `game_state` field (score/period/clock) was removed from this response. Live game state is now served exclusively by the [Game State](/en/api-reference/gamestate) endpoint and the `gamestate` stream channel. Join rows to game state by `event_id`.
+</Callout>
+
 ### Filtering Multiple Values
 
 Use comma-separated values for multi-select filters:
@@ -110,7 +114,6 @@ for arb in data['data']:
       "possibly_stale": false,
       "oldest_odds_age_seconds": 8,
       "warnings": [],
-      "game_state": null,
       "ev_available": true,
       "ev_percentage": 3.5,
       "is_player_prop": false,
@@ -237,7 +240,6 @@ X-Request-Id: req_arb789xyz012
 | `possibly_stale` | boolean | Whether odds may have moved since detection |
 | `oldest_odds_age_seconds` | number\|null | Age of the stalest leg's odds in seconds |
 | `warnings` | string[] | Warning flags. Possible values: `LIVE_GAME`, `LIVE_HIGH_PROFIT_SUSPICIOUS`, `LOW_IMPLIED_TOTAL`, `POTENTIALLY_STALE_ODDS`, `VERY_STALE_ODDS` |
-| `game_state` | object\|null | Live game state (`period`, `clock`, `score_home`, `score_away`) |
 | `ev_available` | boolean | Whether an EV opportunity exists on this market |
 | `ev_percentage` | number\|null | EV percentage if available |
 | `is_player_prop` | boolean | Whether this is a player prop market |

--- a/content/en/api-reference/opportunities-ev.mdx
+++ b/content/en/api-reference/opportunities-ev.mdx
@@ -20,6 +20,10 @@ This endpoint replaces the former `/positive-ev` and `/value-bets` endpoints. Al
 **Multi-book results:** When multiple sportsbooks are +EV on the same selection, the API returns a separate opportunity for **each** book. For example, if DraftKings is +105, FanDuel is +103, and BetMGM is +101 on the same moneyline, you'll see three entries — each with its own `sportsbook`, `odds_american`, `ev_percentage`, `kelly_percent`, and `confidence_score`. Results are sorted by EV% descending by default, so the best-odds book appears first. Use the `sportsbook` filter to narrow to specific books.
 </Callout>
 
+<Callout type="warning">
+**Live game state:** EV rows do not carry scores, period, or clock. Live game state is served exclusively by the [Game State](/en/api-reference/gamestate) endpoint and the `gamestate` stream channel. Join rows to game state by `event_id`.
+</Callout>
+
 ## Authentication
 
 Requires API key. **Pro tier or higher required.** Your account must have the `ev` feature enabled.

--- a/content/en/api-reference/opportunities-low-hold.mdx
+++ b/content/en/api-reference/opportunities-low-hold.mdx
@@ -16,6 +16,10 @@ GET /api/v1/opportunities/low_hold
 
 Requires API key. **Pro tier or higher required.** Your account must have the `low_hold` feature enabled.
 
+<Callout type="warning">
+**Breaking change:** The `game_state` field (score/period/clock) was removed from this response. Live game state is now served exclusively by the [Game State](/en/api-reference/gamestate) endpoint and the `gamestate` stream channel. Join rows to game state by `event_id`.
+</Callout>
+
 ## Query Parameters
 
 | Parameter | Type | Default | Description |
@@ -108,7 +112,6 @@ for hold in data['data']:
       "start_time": "2026-02-08T19:00:00Z",
       "line": null,
       "hold_percentage": 1.8,
-      "game_state": null,
       "side1": {
         "selection": "Los Angeles Lakers",
         "books": ["draftkings", "betmgm"],


### PR DESCRIPTION
## Summary

- Remove the `game_state` row from sample payloads + schema tables on the EV, arbitrage, and low-hold reference pages.
- Add a breaking-change callout on each page pointing readers at `/api/v1/gamestate` and the `gamestate` stream channel.

## Why

The server is dropping the `game_state` object from `/api/v1/opportunities/{ev,arbitrage,low_hold}` — see Mlaz-code/sharp-api-go#61. Live state is exclusive to the gamestate endpoint going forward.

## Test plan

- [x] Local mdx builds without errors
- [ ] Vercel preview renders the three updated pages
- [ ] Callouts visible on `/en/api-reference/opportunities-ev`, `/opportunities-arbitrage`, `/opportunities-low-hold`

This should land **before** the server PR so users see the warning before the field disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)