### PR TITLE
docs(streaming): update concurrent stream cap from 10 to 1 per key

### DIFF
--- a/content/en/api-reference/websocket.mdx
+++ b/content/en/api-reference/websocket.mdx
@@ -592,7 +592,7 @@ WebSocket frames may also carry the HTTP-style `invalid_api_key`, `tier_restrict
 | `1000` | Normal close | Client or server initiated clean close |
 | `4001` | Authentication failure | Check your API key |
 | `4003` | No streaming access | Add WebSocket add-on ($99/mo) or upgrade to Enterprise |
-| `4029` | Stream limit exceeded | Close unused connections (max 10 concurrent) |
+| `4029` | Stream limit exceeded | Close unused connections (default: 1 per key; newer connection wins) |
 
 ## Sequence Numbers
 
@@ -895,7 +895,7 @@ Exceeding your stream limit closes the connection with code `4029`. Close unused
 8. **Implement reconnection** -- Unlike SSE, WebSocket does not auto-reconnect. Use exponential backoff (1s, 2s, 4s, ...) with `from_seq` replay for brief outages
 9. **Wait for `snapshot:complete`** -- This signals all initial data has been sent. Hide loading states after receiving it
 10. **Handle `odds:removed`** -- Remove odds from your local state when you receive this message to avoid showing stale data
-11. **Close unused connections** -- Each connection counts against your 10-stream limit
+11. **Close unused connections** -- Each key allows 1 concurrent stream by default; a second connection on the same key displaces the older one (close `4001`)
 
 ## Related
 

--- a/content/en/pricing.mdx
+++ b/content/en/pricing.mdx
@@ -19,7 +19,7 @@ Choose the plan that fits your betting strategy. All plans include access to our
 | **Enterprise** | Custom | Custom | Custom | Real-time | All | + History, Futures, SLA |
 
 <Callout type="info">
-*Streaming requires the **WebSocket Add-on** ($99/mo) which enables 10 concurrent streaming connections (SSE or WebSocket — same add-on covers both transports).
+*Streaming requires the **WebSocket Add-on** ($99/mo). All paid tiers default to **1 concurrent stream per key** with newer-wins displacement (a second connection kicks the first). Need multiple simultaneous streams for fleet deployments? [Contact sales](mailto:sales@sharpapi.io). SSE and WebSocket share the same add-on and the same limit.
 </Callout>
 
 ## Plan Details
@@ -87,9 +87,10 @@ Choose the plan that fits your betting strategy. All plans include access to our
 
 **$99/month** - Add real-time streaming to any paid tier.
 
-- 10 concurrent SSE streams
+- 1 concurrent SSE/WebSocket stream per key (newer-wins displacement)
 - Sub-second latency
 - Works with Hobby, Pro, Sharp, and Enterprise tiers
+- Fleet limits (>1 stream) available on request
 
 <Callout type="warning">
 The WebSocket add-on requires a paid subscription. Free tier does not support streaming.

--- a/content/en/streaming/overview.mdx
+++ b/content/en/streaming/overview.mdx
@@ -56,10 +56,14 @@ SSE automatically reconnects on disconnect. The server uses `Last-Event-ID` to r
 | Tier | Streaming Access |
 |------|------------------|
 | Free | Not available |
-| Hobby + Add-on ($99/mo) | 10 concurrent streams |
-| Pro + Add-on ($99/mo) | 10 concurrent streams |
-| Sharp + Add-on ($99/mo) | 10 concurrent streams |
+| Hobby + Add-on ($99/mo) | 1 stream (newer-wins displacement) |
+| Pro + Add-on ($99/mo) | 1 stream (newer-wins displacement) |
+| Sharp + Add-on ($99/mo) | 1 stream (newer-wins displacement) |
 | Enterprise | Included (custom limits) |
+
+<Callout type="warning">
+**Newer-wins displacement:** opening a second stream from the same API key closes the first one. One well-managed connection is sufficient for most use cases — see [Single-Connection Patterns](/en/streaming/single-connection) for techniques. Fleet deployments needing multiple simultaneous streams can request a higher limit via [sales](mailto:sales@sharpapi.io).
+</Callout>
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Brings three pages in line with the policy change that landed on the API on **2026-04-27**: every paid tier now defaults to **1 concurrent stream**, with newer-wins displacement (a second connection from the same key sends close `4001 displaced by newer session` to the older one). Fleet limits require a `maxStreams` override in Unkey metadata via Enterprise.

The recently-merged single-connection guide (#198) already reflected the new policy. This PR fixes the **other three** pages that still claimed "10 streams":

- `content/en/streaming/overview.mdx`
- `content/en/pricing.mdx`
- `content/en/api-reference/websocket.mdx`

## Origin

Authored by a parked Paperclip agent on `paperclip/SHA-2174` 12 hours ago, never PR'd. Cherry-picked onto a fresh branch off `origin/main`. The dirty `public/openapi.json` regen in that worktree was deliberately excluded — it's stale generator drift unrelated to this feature.

## Test plan

- [ ] Vercel preview build green
- [ ] Each of the three pages mentions "1 concurrent stream" / "newer-wins displacement"
- [ ] No remaining references to "10 streams" anywhere in the docs (`grep -ri "10 stream" content/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)