### PR TITLE
docs(streaming): document WS close code 1006 as RFC-reserved client-side code

### DIFF
--- a/content/en/api-reference/websocket.mdx
+++ b/content/en/api-reference/websocket.mdx
@@ -590,9 +590,14 @@ WebSocket frames may also carry the HTTP-style `invalid_api_key`, `tier_restrict
 | Code | Meaning | Resolution |
 |------|---------|------------|
 | `1000` | Normal close | Client or server initiated clean close |
+| `1006` | Abnormal closure (client-side) | Network drop or process kill — always reconnect |
 | `4001` | Authentication failure | Check your API key |
 | `4003` | No streaming access | Add WebSocket add-on ($99/mo) or upgrade to Enterprise |
 | `4029` | Stream limit exceeded | Close unused connections (max 10 concurrent) |
+
+<Callout type="warning">
+**Code 1006 is RFC 6455 reserved and is never transmitted over the wire.** Your WebSocket library generates it locally when the TCP connection is lost without a proper closing handshake (network failure, process kill, OS-level timeout). The server did not send it. Always reconnect on 1006.
+</Callout>
 
 ## Sequence Numbers
 

--- a/content/en/streaming/websocket.mdx
+++ b/content/en/streaming/websocket.mdx
@@ -155,9 +155,14 @@ The server keeps a 2-minute replay buffer. Pass `resume=true&from_seq=N` on reco
 | Code | Meaning | Action |
 |------|---------|--------|
 | `1000` | Normal close | No action needed |
+| `1006` | Abnormal closure (client-side) | Network drop — always reconnect |
 | `4001` | Bad or missing API key | Fix your API key |
 | `4003` | No streaming access | Purchase WebSocket add-on |
 | `4029` | Too many connections | Close unused connections first |
+
+<Callout type="warning">
+**Code 1006 is RFC 6455 reserved and never sent by the server.** Your WebSocket library generates it locally when the TCP connection drops without a closing handshake (network failure, process kill). Always reconnect when you see it — the example below already does this correctly by only skipping reconnect on `1000`.
+</Callout>
 
 ## Full API Reference
 


### PR DESCRIPTION
## Summary

Adds close code `1006` to the close-code tables in both the WebSocket streaming guide (`content/en/streaming/websocket.mdx`) and the WebSocket API reference (`content/en/api-reference/websocket.mdx`), with a Callout explaining that **1006 is never transmitted over the wire** — the client WebSocket library generates it locally on abnormal TCP teardown (network loss, process kill).

Developers commonly mistake 1006 for a server-sent code and waste time looking for a server-side cause. The callout surfaces the correct interpretation up front.

## Origin

Authored by a parked Paperclip agent on `paperclip/SHA-2177` 11 hours ago, never PR'd. Cherry-picked onto a fresh branch off `origin/main`. The dirty `public/openapi.json` regen and stray `~/` in that worktree were excluded.

## Test plan

- [ ] Vercel preview build green
- [ ] Both pages now list `1006 (Abnormal Closure)` in their close-code tables
- [ ] Callout renders correctly on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)