### PR TITLE
docs(historical): add CLV and closing odds endpoints (Sharp tier)

### DIFF
--- a/content/en/api-reference/_meta.js
+++ b/content/en/api-reference/_meta.js
@@ -69,6 +69,12 @@ export default {
   account: "Account Info",
   "account-usage": "Usage Stats",
   "account-keys": "API Key Management",
+  "---Historical": {
+    type: "separator",
+    title: "Historical (Sharp+)",
+  },
+  "historical-clv": "Closing Line Value (CLV)",
+  "historical-odds-closing": "Closing Odds by Date",
   "---Enterprise": {
     type: "separator",
     title: "Enterprise",

--- a/content/en/api-reference/historical-clv.mdx
+++ b/content/en/api-reference/historical-clv.mdx
@@ -1,0 +1,264 @@
+---
+description: "GET /api/v1/historical/clv — Closing Line Value analysis across sportsbooks. Compare your closing prices against Pinnacle's no-vig probability to measure edge. Sharp tier required."
+---
+
+import { Callout, Tabs } from 'nextra/components'
+
+# Closing Line Value (CLV)
+
+Analyze how well a sportsbook's closing odds compare to Pinnacle's devigged (no-vig) probability. Positive CLV means the book closed looser than Pinnacle — a historical proxy for edge.
+
+```
+GET /api/v1/historical/clv
+```
+
+<Callout type="warning">
+**Sharp tier or higher required.** Pro and lower tiers receive a `403 tier_restricted` error. This endpoint is gated by the `closing_lines` feature.
+</Callout>
+
+<Callout type="info">
+**Phase 1 data window:** Closing lines are captured in real-time as games go live. The Valkey store retains data for **30 days**. Historical data beyond 30 days is not yet available.
+</Callout>
+
+## How Closing Lines Are Captured
+
+When a game transitions from pre-match to live, the server captures each book's last pre-match odds as that event's closing line. The closing price is devigged using the **Power method** (same as EV calculation) to produce a no-vig probability per selection.
+
+CLV is then computed as:
+
+```
+CLV% = (pin_no_vig_prob - book_no_vig_prob) / book_no_vig_prob × 100
+```
+
+Where `pin_no_vig_prob` is Pinnacle's devigged probability (the sharp reference) and `book_no_vig_prob` is the soft book's devigged probability. A positive CLV% means the soft book closed at a price more favorable than the Pinnacle fair line.
+
+## Authentication
+
+Requires API key. **Sharp tier or higher required** (`closing_lines` feature).
+
+## Query Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `from` | string | 7 days ago | Start date (`YYYY-MM-DD` or ISO 8601). Clamped to 30-day window. |
+| `to` | string | today | End date (`YYYY-MM-DD` or ISO 8601). |
+| `group_by` | string | `sportsbook` | Aggregation dimension. One of: `sportsbook`, `sport`, `league`, `market`, `day`. |
+| `sport` | string | all | Filter by sport(s), comma-separated (e.g. `basketball,football`). |
+| `league` | string | all | Filter by league(s), comma-separated (e.g. `nba,nfl`). |
+| `sportsbook` | string | all | Filter by sportsbook(s), comma-separated. |
+
+### Date Window
+
+Sharp tier allows up to **30 days** of history (the current retention window for closing line data). Requesting dates outside this window is clamped silently to the earliest available date.
+
+## Example Requests
+
+<Tabs items={['cURL', 'JavaScript', 'Python']}>
+  <Tabs.Tab>
+```bash
+# CLV by sportsbook for the past 7 days
+curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?from=2026-04-10&to=2026-04-17&group_by=sportsbook" \
+  -H "X-API-Key: YOUR_API_KEY"
+
+# CLV grouped by sport, NBA only
+curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?league=nba&group_by=sport" \
+  -H "X-API-Key: YOUR_API_KEY"
+
+# CLV grouped by day for DraftKings
+curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?sportsbook=draftkings&group_by=day" \
+  -H "X-API-Key: YOUR_API_KEY"
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```javascript
+const params = new URLSearchParams({
+  from: '2026-04-10',
+  to: '2026-04-17',
+  group_by: 'sportsbook',
+});
+const response = await fetch(
+  `https://api.sharpapi.io/api/v1/historical/clv?${params}`,
+  { headers: { 'X-API-Key': 'YOUR_API_KEY' } }
+);
+const { data, meta } = await response.json();
+for (const group of data.groups) {
+  console.log(`${group.group_key}: avg CLV ${group.avg_clv_percent.toFixed(2)}% (${group.samples} samples)`);
+}
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```python
+import requests
+
+response = requests.get(
+    'https://api.sharpapi.io/api/v1/historical/clv',
+    params={
+        'from': '2026-04-10',
+        'to': '2026-04-17',
+        'group_by': 'sportsbook',
+    },
+    headers={'X-API-Key': 'YOUR_API_KEY'}
+)
+data = response.json()
+for group in data['data']['groups']:
+    print(
+        f"{group['group_key']}: "
+        f"avg CLV {group['avg_clv_percent']:.2f}% "
+        f"({group['samples']} samples)"
+    )
+```
+  </Tabs.Tab>
+</Tabs>
+
+## Response
+
+### Success (200)
+
+```json
+{
+  "success": true,
+  "data": {
+    "group_by": "sportsbook",
+    "groups": [
+      {
+        "group_key": "draftkings",
+        "samples": 312,
+        "avg_clv_percent": 1.42,
+        "avg_abs_clv_percent": 2.18,
+        "distinct_books": 1,
+        "distinct_sports": 4
+      },
+      {
+        "group_key": "fanduel",
+        "samples": 289,
+        "avg_clv_percent": 0.87,
+        "avg_abs_clv_percent": 1.95,
+        "distinct_books": 1,
+        "distinct_sports": 4
+      },
+      {
+        "group_key": "betmgm",
+        "samples": 201,
+        "avg_clv_percent": -0.21,
+        "avg_abs_clv_percent": 1.74,
+        "distinct_books": 1,
+        "distinct_sports": 3
+      }
+    ],
+    "date_range": {
+      "from": "2026-04-10T00:00:00.000",
+      "to": "2026-04-17T00:00:00.000"
+    },
+    "total_events": 58,
+    "comparable_events": 51,
+    "sharp_reference": "pinnacle"
+  },
+  "meta": {
+    "source": "valkey:closing_line",
+    "tier_window_days": 30,
+    "phase": "1",
+    "filters": {
+      "sport": null,
+      "league": null,
+      "sportsbook": null,
+      "group_by": "sportsbook"
+    },
+    "updated_at": "2026-04-17T20:00:00.000000000Z"
+  }
+}
+```
+
+**Empty result (no closing line data yet):**
+
+```json
+{
+  "success": true,
+  "data": {
+    "group_by": "sportsbook",
+    "groups": [],
+    "date_range": { "from": "...", "to": "..." },
+    "total_events": 0,
+    "comparable_events": 0,
+    "sharp_reference": "pinnacle"
+  },
+  "meta": { "source": "valkey:closing_line", "phase": "1", ... }
+}
+```
+
+An empty `groups` array is a valid response when no closing line data has been captured for the requested date range — not an error.
+
+### Error Responses
+
+***403 Tier Restricted***
+```json
+{
+  "error": {
+    "code": "tier_restricted",
+    "message": "The 'closing_lines' feature requires Sharp or higher.",
+    "required_tier": "sharp",
+    "docs": "https://docs.sharpapi.io/en/pricing"
+  }
+}
+```
+
+***400 Validation Error***
+```json
+{
+  "error": {
+    "code": "validation_error",
+    "message": "Invalid group_by. Must be one of: day, league, market, sport, sportsbook"
+  }
+}
+```
+
+## Response Fields
+
+### `data` object
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `group_by` | string | The dimension used for aggregation |
+| `groups` | array | Array of group rows, sorted by `samples` descending |
+| `date_range` | object | Actual `from`/`to` used after tier clamping |
+| `total_events` | integer | Total events found in the date range (before Pinnacle filter) |
+| `comparable_events` | integer | Events with a Pinnacle closing line available for comparison |
+| `sharp_reference` | string | Sharp book used as the fair-odds reference (`"pinnacle"`) |
+
+### Group row fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `group_key` | string | The group identifier (sportsbook name, sport, league, market type, or YYYY-MM-DD date) |
+| `samples` | integer | Number of closing line comparisons in this group |
+| `avg_clv_percent` | number | Average CLV% across all samples. Positive = book closed looser than Pinnacle. |
+| `avg_abs_clv_percent` | number | Average absolute CLV% (direction-agnostic market efficiency measure) |
+| `distinct_books` | integer | Number of distinct books in this group |
+| `distinct_sports` | integer | Number of distinct sports in this group |
+
+### `meta` object
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `source` | string | Always `"valkey:closing_line"` (Phase 1 backend) |
+| `tier_window_days` | integer | Maximum lookback days for your tier (Sharp = 30) |
+| `phase` | string | `"1"` — real-time capture from live transitions. ClickHouse backfill planned for Phase 2. |
+| `updated_at` | string | ISO 8601 response timestamp |
+
+---
+
+## Interpreting CLV
+
+| CLV% | Interpretation |
+|------|----------------|
+| **> +2%** | Book consistently closed significantly looser than sharp lines — high value captured |
+| **+0.5% to +2%** | Book closed slightly loose — typical for recreational books |
+| **-0.5% to +0.5%** | Near-market close — efficient or mixed |
+| **< -0.5%** | Book tightened into close — may indicate steam chasing or sharp-side action |
+
+A positive average CLV on your bets is the strongest indicator that you're betting into inefficient prices. Over a large sample, positive CLV strongly predicts positive ROI.
+
+## Related Endpoints
+
+- [Closing Odds by Date](/en/api-reference/historical-odds-closing) — Per-event raw closing prices for a given date
+- [+EV Opportunities](/en/api-reference/opportunities-ev) — Real-time positive expected value bets
+- [Odds Snapshot](/en/api-reference/odds) — Current pre-match and live odds

--- a/content/en/api-reference/historical-odds-closing.mdx
+++ b/content/en/api-reference/historical-odds-closing.mdx
@@ -1,0 +1,314 @@
+---
+description: "GET /api/v1/historical/odds/closing — Retrieve per-event closing odds with devigged no-vig probabilities for all sportsbooks on a given date. Sharp tier required."
+---
+
+import { Callout, Tabs } from 'nextra/components'
+
+# Historical Closing Odds
+
+Retrieve the closing odds captured for all events on a specific date — the last pre-match price from each sportsbook before a game went live, with Power-devigged no-vig probabilities.
+
+```
+GET /api/v1/historical/odds/closing
+```
+
+<Callout type="warning">
+**Sharp tier or higher required.** Pro and lower tiers receive a `403 tier_restricted` error. This endpoint is gated by the `closing_lines` feature.
+</Callout>
+
+<Callout type="info">
+**Phase 1 data window:** Closing lines are captured in real-time on `isLive` false→true transitions. Valkey retains 30 days of data. Requesting a date older than 30 days will return an empty result.
+</Callout>
+
+## Authentication
+
+Requires API key. **Sharp tier or higher required** (`closing_lines` feature).
+
+## Query Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `date` | string | Yes | Date in `YYYY-MM-DD` format (UTC). |
+| `sport` | string | Yes | Sport identifier, e.g. `basketball`, `football`, `ice_hockey`. |
+| `league` | string | Yes | League identifier, e.g. `nba`, `nfl`, `nhl`. |
+
+All three parameters are required. The response is filtered to events matching the exact sport and league on that UTC date.
+
+### Date Window
+
+Sharp tier allows up to **30 days** of lookback. Requesting a date beyond your tier window returns a `403 tier_restricted` error with the allowed window size.
+
+## Example Requests
+
+<Tabs items={['cURL', 'JavaScript', 'Python']}>
+  <Tabs.Tab>
+```bash
+# NBA closing lines for April 10
+curl -X GET "https://api.sharpapi.io/api/v1/historical/odds/closing?date=2026-04-10&sport=basketball&league=nba" \
+  -H "X-API-Key: YOUR_API_KEY"
+
+# NFL closing lines
+curl -X GET "https://api.sharpapi.io/api/v1/historical/odds/closing?date=2026-04-06&sport=football&league=nfl" \
+  -H "X-API-Key: YOUR_API_KEY"
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```javascript
+const params = new URLSearchParams({
+  date: '2026-04-10',
+  sport: 'basketball',
+  league: 'nba',
+});
+const response = await fetch(
+  `https://api.sharpapi.io/api/v1/historical/odds/closing?${params}`,
+  { headers: { 'X-API-Key': 'YOUR_API_KEY' } }
+);
+const { data } = await response.json();
+console.log(`Found ${data.total_events} events, ${data.total_lines} closing lines`);
+for (const event of data.events) {
+  for (const book of event.books) {
+    const ml = book.lines.find(l => l.market_type === 'moneyline');
+    if (ml) {
+      console.log(`${event.away_team} @ ${event.home_team} — ${book.book}: ${ml.odds_american}`);
+    }
+  }
+}
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```python
+import requests
+
+response = requests.get(
+    'https://api.sharpapi.io/api/v1/historical/odds/closing',
+    params={
+        'date': '2026-04-10',
+        'sport': 'basketball',
+        'league': 'nba',
+    },
+    headers={'X-API-Key': 'YOUR_API_KEY'}
+)
+data = response.json()['data']
+print(f"{data['total_events']} events, {data['total_lines']} lines")
+for event in data['events']:
+    print(f"\n{event['away_team']} @ {event['home_team']}")
+    for book in event['books']:
+        for line in book['lines']:
+            if line['market_type'] == 'moneyline':
+                nv = line.get('no_vig_probability')
+                print(f"  {book['book']}: {line['odds_american']} (no-vig: {nv:.3f})" if nv else f"  {book['book']}: {line['odds_american']}")
+```
+  </Tabs.Tab>
+</Tabs>
+
+## Response
+
+### Success (200)
+
+```json
+{
+  "success": true,
+  "data": {
+    "date": "2026-04-10",
+    "sport": "basketball",
+    "league": "nba",
+    "events": [
+      {
+        "event_id": "evt_nba_bos_mia_20260410",
+        "sport": "basketball",
+        "league": "nba",
+        "home_team": "Boston Celtics",
+        "away_team": "Miami Heat",
+        "event_start_time": "2026-04-10T18:00:00Z",
+        "first_captured_at": "2026-04-10T17:58:12.000000000Z",
+        "books": [
+          {
+            "book": "pinnacle",
+            "captured_at": "2026-04-10T17:58:12.000000000Z",
+            "lines": [
+              {
+                "market_type": "moneyline",
+                "selection": "Boston Celtics",
+                "selection_type": "home",
+                "line": null,
+                "odds_american": -145,
+                "odds_decimal": 1.690,
+                "implied_probability": 0.5920,
+                "no_vig_probability": 0.5813
+              },
+              {
+                "market_type": "moneyline",
+                "selection": "Miami Heat",
+                "selection_type": "away",
+                "line": null,
+                "odds_american": 125,
+                "odds_decimal": 2.250,
+                "implied_probability": 0.4444,
+                "no_vig_probability": 0.4187
+              },
+              {
+                "market_type": "point_spread",
+                "selection": "Boston Celtics",
+                "selection_type": "home",
+                "line": -3.5,
+                "odds_american": -110,
+                "odds_decimal": 1.909,
+                "implied_probability": 0.5238,
+                "no_vig_probability": 0.5000
+              }
+            ]
+          },
+          {
+            "book": "draftkings",
+            "captured_at": "2026-04-10T17:57:44.000000000Z",
+            "lines": [
+              {
+                "market_type": "moneyline",
+                "selection": "Boston Celtics",
+                "selection_type": "home",
+                "line": null,
+                "odds_american": -140,
+                "odds_decimal": 1.714,
+                "implied_probability": 0.5833,
+                "no_vig_probability": 0.5730
+              },
+              {
+                "market_type": "moneyline",
+                "selection": "Miami Heat",
+                "selection_type": "away",
+                "line": null,
+                "odds_american": 118,
+                "odds_decimal": 2.180,
+                "implied_probability": 0.4587,
+                "no_vig_probability": 0.4270
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "total_events": 5,
+    "total_lines": 48
+  },
+  "meta": {
+    "source": "valkey:closing_line",
+    "tier_window_days": 30,
+    "filters": {
+      "sport": "basketball",
+      "league": "nba",
+      "date": "2026-04-10"
+    },
+    "updated_at": "2026-04-17T20:00:00.000000000Z"
+  }
+}
+```
+
+### Error Responses
+
+***400 Validation Error***
+```json
+{
+  "error": {
+    "code": "validation_error",
+    "message": "date parameter is required in YYYY-MM-DD format"
+  }
+}
+```
+
+***403 Tier Restricted (wrong tier)***
+```json
+{
+  "error": {
+    "code": "tier_restricted",
+    "message": "The 'closing_lines' feature requires Sharp or higher.",
+    "required_tier": "sharp",
+    "docs": "https://docs.sharpapi.io/en/pricing"
+  }
+}
+```
+
+***403 Tier Restricted (date too old)***
+```json
+{
+  "error": {
+    "code": "tier_restricted",
+    "message": "Your sharp plan allows historical data up to 30 days back",
+    "tier": "sharp",
+    "docs": "https://sharpapi.io/pricing"
+  }
+}
+```
+
+## Response Fields
+
+### `data` object
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `date` | string | The requested date (`YYYY-MM-DD`) |
+| `sport` | string | Sport filter applied |
+| `league` | string | League filter applied |
+| `events` | array | Closing line events matching the date, sport, and league |
+| `total_events` | integer | Number of events in the response |
+| `total_lines` | integer | Total number of individual closing lines across all events and books |
+
+### Event object
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `event_id` | string | Unique event identifier |
+| `sport` | string | Sport |
+| `league` | string | League |
+| `home_team` | string | Home team name |
+| `away_team` | string | Away team name |
+| `event_start_time` | string | ISO 8601 scheduled start time |
+| `first_captured_at` | string | ISO 8601 timestamp of the first closing line capture for this event |
+| `books` | array | Per-book closing line payloads |
+
+### Book object
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `book` | string | Sportsbook identifier |
+| `captured_at` | string | ISO 8601 timestamp when this book's closing line was captured |
+| `lines` | array | Array of closing line entries for this book |
+
+### Closing line entry
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `market_type` | string | Market type: `moneyline`, `point_spread`, `total_points`, etc. |
+| `selection` | string | Selection label (team name, Over/Under, player) |
+| `selection_type` | string | `home`, `away`, `over`, `under`, etc. |
+| `line` | number\|null | Spread or total value (`-3.5`, `220.5`). `null` for moneylines. |
+| `player_name` | string | Player name for player props (omitted otherwise) |
+| `stat_category` | string | Stat type for player props (omitted otherwise) |
+| `odds_american` | integer | American odds at close |
+| `odds_decimal` | number | Decimal odds at close |
+| `implied_probability` | number | Raw implied probability (with vig) |
+| `no_vig_probability` | number\|null | Power-devigged fair probability (0.0–1.0). Present for 2- and 3-way markets; `null` for single-selection markets. |
+| `timestamp` | string | ISO 8601 timestamp of the odds record used for capture |
+
+### `meta` object
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `source` | string | Always `"valkey:closing_line"` (Phase 1 backend) |
+| `tier_window_days` | integer | Maximum lookback days for your tier (Sharp = 30) |
+| `updated_at` | string | ISO 8601 response timestamp |
+
+---
+
+## Use Cases
+
+**CLV analysis:** Compare `no_vig_probability` values across books against Pinnacle. A soft book with a higher `no_vig_probability` on the favorite closed looser — positive CLV for bettors who took that side.
+
+**Line shopping audit:** Retrieve closing lines across all books to understand where value was available at close.
+
+**Model calibration:** Use `implied_probability` and `no_vig_probability` as historical ground truth for calibrating your own probability models.
+
+## Related Endpoints
+
+- [Closing Line Value (CLV)](/en/api-reference/historical-clv) — Aggregate CLV% rollups grouped by sportsbook, sport, league, or day
+- [Odds Snapshot](/en/api-reference/odds) — Current real-time odds
+- [+EV Opportunities](/en/api-reference/opportunities-ev) — Real-time positive expected value bets

--- a/content/en/pricing.mdx
+++ b/content/en/pricing.mdx
@@ -77,6 +77,8 @@ Choose the plan that fits your betting strategy. All plans include access to our
     - Real-time data
     - All sportsbooks
     - All Pro features
+    - Closing Line Value (CLV)
+    - Closing Odds History (30 days)
     - Priority Support
 
     Get Started
@@ -101,7 +103,6 @@ Need higher limits, custom features, or an SLA? Contact us for enterprise pricin
 
 - Custom rate limits
 - Custom concurrent streams
-- [Historical Odds](/en/api-reference/enterprise) - Odds movements and closing lines
 - [Futures](/en/api-reference/enterprise) - Futures markets and cross-book odds
 - Dedicated support
 - Service Level Agreement (SLA)
@@ -127,6 +128,8 @@ Need higher limits, custom features, or an SLA? Contact us for enterprise pricin
 | `GET /splits` | No | No | Yes | Yes | Yes |
 | `GET /splits/history` | No | No | Yes | Yes | Yes |
 | `GET /odds/closing` | No | No | Yes | Yes | Yes |
+| `GET /historical/clv` | No | No | No | Yes | Yes |
+| `GET /historical/odds/closing` | No | No | No | Yes | Yes |
 | `GET /futures` | No | No | No | No | Yes |
 | CSV Export | No | No | Yes | Yes | Yes |
 | Streaming (SSE + WS) | No | +$99/mo | +$99/mo | +$99/mo | Included |


### PR DESCRIPTION
## Summary

Documents two now-live, Sharp-tier-gated historical endpoints:

- `GET /api/v1/historical/clv` — closing-line value computation
- `GET /api/v1/historical/odds/closing` — closing-odds history (30-day Phase 1 retention)

Both are confirmed live in `sharp-api-go/main.go` (lines 5326, 5330) and gated behind the `closing_lines` feature flag (Sharp tier).

## What's covered

- **`historical-clv.mdx`** (264 lines) — endpoint reference: query params, response schema (Power devig math), tier-restricted 403 error shape, request/response examples.
- **`historical-odds-closing.mdx`** (314 lines) — endpoint reference: 30-day retention window, Valkey-backed schema, examples.
- **`pricing.mdx`** — adds CLV / Closing Odds History as Sharp plan features; adds both endpoints to the feature comparison table next to the existing `/odds/closing` and `/splits` rows.
- **`api-reference/_meta.js`** — adds the two pages to the API Reference sidebar.

## Origin

Authored by a parked Paperclip agent on `paperclip/SHA-1870` two weeks ago (Apr 17), never PR'd. Cherry-picked onto a fresh branch off `origin/main`. One conflict in `pricing.mdx` (the feature-comparison table had three new rows added since — `/splits`, `/splits/history`, `/odds/closing` — and the bullet list had `[Historical Odds]` and `[Game State]` removed via #195). Resolved by **merging both sets** (all five new rows now in the table) — the three new endpoints in main and the two from this branch are distinct real endpoints, not duplicates.

## Test plan

- [ ] Vercel preview build green
- [ ] Both new pages render and appear in the API Reference sidebar
- [ ] Pricing page's feature comparison shows all five `/splits`, `/odds/closing`, `/historical/clv`, `/historical/odds/closing` rows
- [ ] Endpoint examples in the new pages can be exercised live: `ssh ovh "curl -H 'X-API-Key: $SHARPAPI_KEY' http://localhost:3003/api/v1/historical/clv?..."`

🤖 Generated with [Claude Code](https://claude.com/claude-code)