### PR TITLE
docs(websocket): mark sharpapi-v1.5 as internal-only

### DIFF
--- a/public/asyncapi.yaml
+++ b/public/asyncapi.yaml
@@ -12,18 +12,18 @@ info:
 
     ## Subprotocols
 
-    The server negotiates one of two subprotocols on upgrade. Pass the chosen
-    name in the `Sec-WebSocket-Protocol` header (browsers: second arg to the
-    `WebSocket` constructor).
+    Public clients negotiate `sharpapi-v1` by passing it in the
+    `Sec-WebSocket-Protocol` header (browsers: second arg to the `WebSocket`
+    constructor). It carries JSON throughout.
 
-    | Subprotocol      | Wire format for `data` payloads          | When to use                       |
-    |------------------|------------------------------------------|-----------------------------------|
-    | `sharpapi-v1`    | JSON throughout                          | Browsers, simple clients          |
-    | `sharpapi-v1.5`  | JSON control frames + MessagePack data   | High-throughput servers, SDKs     |
+    | Subprotocol   | Wire format for `data` payloads | When to use         |
+    |---------------|---------------------------------|---------------------|
+    | `sharpapi-v1` | JSON throughout                 | All public clients  |
 
-    Both protocols deliver the same logical messages with the same field names;
-    `sharpapi-v1.5` swaps the `data` payload binary encoding for ~30% smaller
-    frames at the cost of needing a MessagePack decoder.
+    The server may also accept additional subprotocols reserved for first-party
+    SDKs and internal services. Those are not part of the documented public API
+    and may change without notice — public clients should always negotiate
+    `sharpapi-v1`.
 
     ## Authentication
 


### PR DESCRIPTION
## Summary

- Removes `sharpapi-v1.5` from the public subprotocol table in `public/asyncapi.yaml`
- Replaces the explanatory paragraph with a note that additional subprotocols exist but are reserved for first-party SDKs / internal services
- Public clients should always negotiate `sharpapi-v1`

## Why

The MessagePack subprotocol is internal-only — only `/root/sharp-lines/` (our sister product) negotiates it, and the cross-repo audit on 2026-04-22 explicitly tagged it `NOT APPLICABLE` for public docs. Today a customer-support agent (Maya) recommended it to a customer debugging unrelated 60s WS disconnects (already fixed server-side in sharp-api-go PR #177 / SHA-2188), citing this asyncapi spec as the source. Removing the public reference closes the leak.

No code change in sharp-api-go — the server still accepts both subprotocols on the wire (and will continue to, for the internal SDK and SharpLines). This is a docs-only correction.

## Test plan

- [ ] Vercel preview renders the subprotocol table correctly (single row, `sharpapi-v1`)
- [ ] No broken anchor links from other doc pages referring to v1.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)