### PR TITLE
fix(hydration): suppress React #418 errors from Nextra internals (SHA-2240)

### DIFF
--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -55,7 +55,7 @@ export default async function LangLayout({ children, params }) {
       <Head color={{ hue: 210 }}>
         <SiteStructuredData />
       </Head>
-      <body>
+      <body suppressHydrationWarning>
         <PostHogProvider>
           <Layout
             pageMap={await getPageMap(`/${lang}`)}
@@ -64,9 +64,6 @@ export default async function LangLayout({ children, params }) {
             toc={{ backToTop: true }}
             feedback={{ content: null }}
             editLink={null}
-            i18n={[
-              { locale: 'en', name: 'English' },
-            ]}
             navbar={
               <Navbar
                 logo={logo}

--- a/components/PostHogProvider.tsx
+++ b/components/PostHogProvider.tsx
@@ -13,6 +13,12 @@ const IGNORED_PATTERNS = [
   /ChunkLoadError/,
   /Loading chunk/,
   /prism_bash_exports/,  // browser extension (PrismJS-based dev tools) injecting into the page
+  // React hydration errors (#418, #423, #425) — mismatches are from Nextra internals
+  // (next-themes localStorage reads, Switchers conditional rendering). Suppressed at
+  // the DOM level via suppressHydrationWarning; PostHog sees them as noise.
+  /Hydration failed/,
+  /There was an error while hydrating/,
+  /Text content did not match/,
 ]
 
 function shouldIgnore(message: string): boolean {
@@ -111,7 +117,7 @@ function DocsEventCapture() {
   return null
 }
 
-export function PostHogProvider({ children }: { children: React.ReactNode }) {
+export function PostHogProvider({ children }: { children?: React.ReactNode }) {
   return (
     <PHProvider client={posthog}>
       <DocsEventCapture />


### PR DESCRIPTION
## Summary

- Add `suppressHydrationWarning` to `<body>` — guards against `next-themes` writing `data-theme` from `localStorage` before React reconciles; without this, ThemeProvider causes a body-level #418 on every cold page load
- Remove `i18n` prop from `Layout` — docs has a single locale (`en`); the prop caused Nextra's `Switchers` component to mount `LocaleSwitch` in the footer on page-type routes, producing an "HTML vs text" structural mismatch between SSR and client trees (confirmed absent from built output via `$L1c` mount reference check)
- Extend PostHog `IGNORED_PATTERNS` with React hydration error strings — defense-in-depth; the structural fixes are the real solution, but filtering prevents false-positive error tracking while residual instances fade post-deploy

## Background

A PostHog handler change deployed 2026-05-04 surfaced latent React #418 hydration errors (26+ in a partial day). The errors predate the handler change; the new `window.addEventListener('error')` handler just made them visible.

## QA

- Build clean: 55 pages, 0 TypeScript/compile errors, 6,357 links fixed, Pagefind indexed 53 pages
- `LocaleSwitch` mount reference (`\$L1c`) absent from rendered `out/en/pricing.html` → i18n removal effective
- `<body suppressHydrationWarning>` and `IGNORED_PATTERNS` updates verified in source

Closes SHA-2240

🤖 Generated with [Claude Code](https://claude.com/claude-code)