### PR TITLE
docs(openapi): remove phantom /sports/{sportId} and /sportsbooks/{bookId} (#205)

### DIFF
--- a/public/openapi.json
+++ b/public/openapi.json
@@ -13,8 +13,8 @@
       "name": "Proprietary",
       "url": "https://sharpapi.io/terms"
     },
-    "x-generated-at": "2026-04-16T19:00:23-04:00",
-    "x-commit-sha": "60018c8"
+    "x-generated-at": "2026-04-23T20:18:17-04:00",
+    "x-commit-sha": "39e2c5d"
   },
   "servers": [
     {
@@ -476,68 +476,6 @@
         }
       }
     },
-    "/sports/{sportId}": {
-      "get": {
-        "operationId": "getSport",
-        "summary": "Get sport by ID",
-        "description": "Returns details for a single sport.",
-        "tags": [
-          "Reference Data"
-        ],
-        "security": [
-          {
-            "ApiKeyHeader": []
-          },
-          {
-            "BearerAuth": []
-          },
-          {
-            "ApiKeyQuery": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "sportId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "example": "basketball"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Sport details",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/DataEnvelope"
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "data": {
-                          "$ref": "#/components/schemas/Sport"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      }
-    },
     "/leagues": {
       "get": {
         "operationId": "listLeagues",
@@ -749,68 +687,6 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/sportsbooks/{bookId}": {
-      "get": {
-        "operationId": "getSportsbook",
-        "summary": "Get sportsbook by ID",
-        "description": "Returns details for a single sportsbook.",
-        "tags": [
-          "Reference Data"
-        ],
-        "security": [
-          {
-            "ApiKeyHeader": []
-          },
-          {
-            "BearerAuth": []
-          },
-          {
-            "ApiKeyQuery": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "bookId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "example": "draftkings"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Sportsbook details",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/DataEnvelope"
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "data": {
-                          "$ref": "#/components/schemas/Sportsbook"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
           }
         }
       }
@@ -4343,12 +4219,18 @@
           },
           "possession": {
             "type": "string",
-            "enum": ["home", "away"],
+            "enum": [
+              "home",
+              "away"
+            ],
             "description": "Which team has possession (team sports) or is receiving (tennis)."
           },
           "server": {
             "type": "string",
-            "enum": ["home", "away"],
+            "enum": [
+              "home",
+              "away"
+            ],
             "description": "Tennis only — current server."
           },
           "last_play": {
@@ -4389,7 +4271,10 @@
           },
           "power_play": {
             "type": "string",
-            "enum": ["home", "away"],
+            "enum": [
+              "home",
+              "away"
+            ],
             "description": "Hockey only — which team is on the power play."
           },
           "sets_home": {
@@ -4426,7 +4311,10 @@
           },
           "batting_team": {
             "type": "string",
-            "enum": ["home", "away"],
+            "enum": [
+              "home",
+              "away"
+            ],
             "description": "Cricket only."
           },
           "stale": {


### PR DESCRIPTION
## Summary

Closes #205. Both routes were declared in `public/openapi.json` but never implemented in `sharp-api-go` — every customer call hits the bare Go ServeMux 404. The list endpoints `/sports` and `/sportsbooks` already cover the use case, so per the issue's own recommendation we strip the singular path-param variants.

## Re-test of the other 5 routes the issue called out

Since the issue was filed (2026-05-04), the `/account/*` namespace and `/stream` were implemented in `sharp-api-go`. Confirmed against live `api.sharpapi.io`:

| Route | Result |
|---|---|
| `GET /api/v1/account` | **200** |
| `GET /api/v1/account/keys` | **400** (validates input — route exists) |
| `POST /api/v1/account/keys` | **400** (validates input — route exists) |
| `GET /api/v1/account/usage` | **200** |
| `DELETE /api/v1/account/keys/{id}` | **400** (validates input — route exists) |
| `POST /api/v1/account/keys/{id}/rotate` | **400** (validates input — route exists) |
| `GET /api/v1/stream` | **200** (SSE streams) |
| `GET /api/v1/sports/{sportId}` | **404** ← still phantom, removed |
| `GET /api/v1/sportsbooks/{bookId}` | **404** ← still phantom, removed |

So this PR closes #205 by aligning the spec with the live backend.

## Verification

- [x] `npm run build` clean (53 pages indexed, 0 errors)
- [x] `python3 -m json.tool public/openapi.json` parses
- [x] No orphan references to `getSport`/`getSportsbook` operationIds in spec or content/
- [x] Targeted byte-range removal so the diff captures only the two deleted paths (the `x-generated-at` / `x-commit-sha` and `enum` formatting deltas are the build pipeline's normal `JSON.stringify(spec, null, 2)` output via `scripts/stamp-openapi.mjs`)

## Test plan

- [x] Spec validates as OpenAPI 3.1.0
- [x] Static export still builds
- [ ] Vercel preview deploys
- [ ] Spot-check Mintlify / docs frontend renders without those routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)