### PR TITLE
docs(leagues): replace stale Leagues-by-Sport table with live-endpoint pointer (Item #3)

### DIFF
--- a/content/en/api-reference/leagues.mdx
+++ b/content/en/api-reference/leagues.mdx
@@ -255,58 +255,25 @@ for league in result['data']:
 | `event_count` | integer | Total events currently available with odds |
 | `live_count` | integer | Events currently live/in-play |
 
-## Leagues by Sport
+## Common Leagues
 
-### Basketball
-| ID | Display Name | Description |
-|----|-------------|-------------|
-| `nba` | NBA | National Basketball Association |
-| `ncaab` | NCAAB | NCAA Men's Basketball |
-| `wnba` | WNBA | Women's National Basketball Association |
+The endpoint is the canonical source of truth — call `GET /api/v1/leagues` for the complete, up-to-date list. The atlas registry catalogs **600+ leagues across 30+ sports** including UEFA continental competitions, multiple basketball circuits per country, and full tennis/golf/MMA/esports/cricket coverage. The illustrative subset below shows the highest-volume entries you'll typically filter on:
 
-### Football
-| ID | Display Name | Description |
-|----|-------------|-------------|
-| `nfl` | NFL | National Football League |
-| `ncaaf` | NCAAF | NCAA Football |
-
-### Hockey
-| ID | Display Name | Description |
-|----|-------------|-------------|
-| `nhl` | NHL | National Hockey League |
-
-### Baseball
-| ID | Display Name | Description |
-|----|-------------|-------------|
-| `mlb` | MLB | Major League Baseball |
-
-### Soccer
-| ID | Display Name | Description |
-|----|-------------|-------------|
-| `epl` | English Premier League | English Premier League |
-| `la_liga` | La Liga | Spanish La Liga |
-| `serie_a` | Serie A | Italian Serie A |
-| `bundesliga` | Bundesliga | German Bundesliga |
-| `mls` | MLS | Major League Soccer |
-
-### Tennis
-| ID | Display Name | Description |
-|----|-------------|-------------|
-| `atp` | ATP | Association of Tennis Professionals |
-| `wta` | WTA | Women's Tennis Association |
-
-### MMA
-| ID | Display Name | Description |
-|----|-------------|-------------|
-| `ufc` | UFC | Ultimate Fighting Championship |
-
-### Golf
-| ID | Display Name | Description |
-|----|-------------|-------------|
-| `pga` | PGA Tour | Professional Golfers' Association Tour |
+| Sport | Common league IDs |
+|-------|-------------------|
+| Basketball | `nba`, `ncaab`, `wnba` |
+| Football | `nfl`, `ncaaf` |
+| Hockey | `nhl` |
+| Baseball | `mlb` |
+| Soccer | `england_-_premier_league`, `spain_-_la_liga`, `italy_-_serie_a`, `germany_-_bundesliga`, `france_-_ligue_1`, `uefa_-_champions_league`, `usa_-_major_league_soccer` |
+| Tennis | `atp`, `wta`, `atp_challenger`, `itf_men`, `itf_women` |
+| MMA | `ufc`, `pfl` |
+| Golf | `pga`, `liv`, `dp_world_tour`, `lpga` |
 
 <Callout type="info">
-The `event_count` and `live_count` values are dynamic. Off-season leagues (e.g., MLB in winter, WNBA in fall) will show 0 events.
+- League IDs use canonical slug form (`england_-_premier_league`, not `epl`). Some short forms are accepted as filter input for backward compatibility, but the canonical slug is what `/leagues` returns and what other endpoints emit on response payloads.
+- The `event_count` and `live_count` values are dynamic. Off-season leagues (e.g., MLB in winter, WNBA in fall) show 0 events but stay in the catalog.
+- For programmatic access (e.g. building dropdown filters), call `/api/v1/leagues` and use the response — never hard-code a list.
 </Callout>
 
 ## Using Leagues in Filters


### PR DESCRIPTION
## Summary

Closes the **last of 4 drift traps** named in [[League Normalization Next Steps]] §Item #3. After this lands: api-adapters#538 + sharp-api-go#367 + sharpapi-site#87 + this PR fully address the original wiki entry.

## Problem

`content/en/api-reference/leagues.mdx` had a hand-maintained "Leagues by Sport" table with 16 entries across 8 sports — against the atlas registry's **600+ leagues across 30+ sports**.

Two issues:

1. **Drift trap**: required manual update on every registry addition. Coverage has been silently shrinking — soccer entries listed 5 leagues but the registry has 295.
2. **Wrong canonical IDs in the docs**: showed `epl`, `la_liga`, `serie_a`, `bundesliga`, `mls`. None are the registry's canonical slug forms (`england_-_premier_league`, `spain_-_la_liga`, `italy_-_serie_a`, `germany_-_bundesliga`, `usa_-_major_league_soccer`). The API does accept short forms for backward compat, but `/leagues` returns canonical slugs and other endpoints emit them on response payloads. Clients copying the doc example saw their `epl` filter "work" but their response-side `eventId` come back containing `england_-_premier_league` and assumed our docs were lying.

## Fix

Replace the static table with a "Common Leagues" callout that:

- Is honest about being illustrative not exhaustive
- Uses canonical slug form for soccer (the most affected sport)
- Adds programmatic-access guidance ("never hard-code a list, call /api/v1/leagues") explicitly
- Mentions registry breadth (600+ leagues / 30+ sports) so readers understand the table is a tiny subset

## Diff

`content/en/api-reference/leagues.mdx`: 63 lines → 15 lines (the static 8-section table → a single illustrative table + callout). Net -48 lines, +15 lines.

## Test plan

- [x] `npm run build` clean (full Next.js + Nextra static export, exit 0)
- [ ] Vercel preview renders the new "Common Leagues" section correctly with the Callout

🤖 Generated with [Claude Code](https://claude.com/claude-code)