### PR TITLE
fix(observability): match minified React error format in PostHog filter (SHA-2377)

### DIFF
--- a/components/PostHogProvider.tsx
+++ b/components/PostHogProvider.tsx
@@ -12,10 +12,19 @@ const IGNORED_PATTERNS = [
   /moz-extension:\/\//,
   /ChunkLoadError/,
   /Loading chunk/,
-  /prism_bash_exports/,  // browser extension (PrismJS-based dev tools) injecting into the page
-  // React hydration errors (#418, #423, #425) — mismatches are from Nextra internals
-  // (next-themes localStorage reads, Switchers conditional rendering). Suppressed at
-  // the DOM level via suppressHydrationWarning; PostHog sees them as noise.
+  // PrismJS-based browser extensions inject a global Prism whose dynamic-import
+  // chunks fail to resolve. Generalized from the prism_bash_exports special-case
+  // shipped in SHA-2240 to also cover prism_python_exports and future variants.
+  /prism_\w+_exports/,
+  /Export 'prism_/,
+  /local binding for export 'prism_/,
+  // React hydration/render errors (#418, #423, #425) — mismatches are from Nextra
+  // internals (next-themes localStorage reads, Switchers conditional rendering).
+  // Suppressed at the DOM level via suppressHydrationWarning. The unminified-message
+  // patterns below remain for dev/local builds; production minification emits as
+  // "Minified React error #N" — that's the form PostHog actually captures, so we
+  // need to match both shapes.
+  /Minified React error #(310|418|423|425)/,
   /Hydration failed/,
   /There was an error while hydrating/,
   /Text content did not match/,


### PR DESCRIPTION
## Summary

Completes [SHA-2240](https://github.com/Sharp-API/SharpAPI-Documentation/commit/25b7d89) (`fix(hydration): suppress React #418 errors from Nextra internals`). That commit shipped `suppressHydrationWarning` on `<body>` + i18n-prop removal + IGNORED_PATTERNS for unminified error messages — but production builds minify React errors as `"Minified React error #N; visit https://react.dev/errors/N..."`, the form PostHog actually captures.

PostHog 14d audit (2026-05-08): docs continued ingesting **125 React #418 hits across 84 distinct users** after SHA-2240 — all in the minified format the existing patterns don't match.

## Changes

`components/PostHogProvider.tsx`:

1. Add `/Minified React error #(310|418|423|425)/` so production-minified React errors are filtered alongside the un-minified dev-build versions.

2. Generalize the `prism_bash_exports` special-case to `/prism_\w+_exports/` plus `/Export 'prism_/` + `/local binding for export 'prism_/`. Same root cause (PrismJS-based browser extensions injecting into the page); the audit showed `prism_python_exports` also firing alongside `prism_bash`.

## Why this is safe

Pure analytics-filter change; no runtime behavior modified. SHA-2240's DOM-level `suppressHydrationWarning` remains the actual hydration fix — this PR only stops the residual mismatch from inflating the PostHog metric.

If a future hydration regression emerges that *isn't* covered by `suppressHydrationWarning`, it'll still surface in dev (unminified) and via the underlying user funnel — only the production noise count is muted.

## Companion PR

sharpapi-site carries matching changes — https://github.com/Mlaz-code/sharpapi-site/pull/92.

## Test plan

- [x] TypeScript clean (`npm run typecheck`)
- [ ] After deploy, PostHog `$exception` rate drops to baseline of ~5–8/day on docs (currently ~15–36/day)
- [ ] Manual: trigger one real error in dev to confirm filter doesn't swallow legitimate errors

## Cross-references

- SHA-2377 — observability ticket
- SHA-2240 — original docs hydration fix this completes
- sharpapi-site PR #92 — companion change

🤖 Generated with [Claude Code](https://claude.com/claude-code)