### PR TITLE
ci: SHA-pin GitHub Actions + pin the Vercel CLI

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -26,11 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -55,16 +55,16 @@ jobs:
     outputs:
       preview_url: ${{ steps.deploy.outputs.preview_url }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
           cache: 'pnpm'
 
-      - run: npm install --global vercel@latest
+      - run: npm install --global vercel@53
 
       - run: vercel pull --yes --environment=preview --token=$VERCEL_TOKEN
 
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.dry_run == true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 10
       - run: |

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -37,11 +37,11 @@ jobs:
     timeout-minutes: 10
     if: inputs.rollback != true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -73,7 +73,7 @@ jobs:
     outputs:
       previous_deployment: ${{ steps.backup.outputs.deployment_url }}
     steps:
-      - run: npm install --global vercel@latest
+      - run: npm install --global vercel@53
 
       - name: Get current production deployment
         id: backup
@@ -93,16 +93,16 @@ jobs:
     outputs:
       deployment_url: ${{ steps.deploy.outputs.deployment_url }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
           cache: 'pnpm'
 
-      - run: npm install --global vercel@latest
+      - run: npm install --global vercel@53
 
       - run: vercel pull --yes --environment=production --token=$VERCEL_TOKEN
 
@@ -124,7 +124,7 @@ jobs:
     timeout-minutes: 10
     if: inputs.rollback == true
     steps:
-      - run: npm install --global vercel@latest
+      - run: npm install --global vercel@53
 
       - name: Determine rollback target
         id: target
@@ -153,7 +153,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -234,7 +234,7 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.dry_run == true && inputs.rollback != true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 10
       - run: |

--- a/.github/workflows/gsc-submit.yml
+++ b/.github/workflows/gsc-submit.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Submit sitemap
         env:

--- a/.github/workflows/indexnow.yml
+++ b/.github/workflows/indexnow.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.event_name == 'push'
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
 


### PR DESCRIPTION
## Summary
`actions/checkout` / `actions/setup-node` were on floating `@v6` tags and the Vercel CLI was installed at `@latest` on every deploy. Pin them so a tag move / supply-chain compromise can't silently change what runs (`VERCEL_TOKEN` is in scope of those `npm i -g vercel` steps). `pnpm/action-setup`, `softprops/action-gh-release`, `orhun/git-cliff-action` were already SHA-pinned.

| was | now |
|---|---|
| `actions/checkout@v6` | `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2` |
| `actions/setup-node@v6` | `actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0` |
| `npm install --global vercel@latest` (×4) | `vercel@53` |

## Test plan
- [ ] CI green; a dev deploy still works with the pinned Vercel CLI

## Notes
Part of a fleet-wide SHA-pin sweep — companion PRs in api-adapters / sharp-api-go / sharpapi-site.