### PR TITLE
fix(docs): tag empty code fences on top-level pages (sharpapi-site #83 Issue 3)

### DIFF
--- a/content/de/authentication.mdx
+++ b/content/de/authentication.mdx
@@ -66,7 +66,7 @@ Vollständige Details finden Sie unter [Preise](/de/pricing).
 
 Rate-Limits werden pro API-Schlüssel durchgesetzt. Aktuelle Limits werden in den Antwort-Headern zurückgegeben:
 
-```
+```http
 X-RateLimit-Limit: 300
 X-RateLimit-Remaining: 299
 X-RateLimit-Reset: 1705804800

--- a/content/de/index.mdx
+++ b/content/de/index.mdx
@@ -16,7 +16,7 @@ SharpAPI ist eine Echtzeit-Aggregationsplattform für Sportwettquoten, die Folge
 
 ## Basis-URL
 
-```
+```text
 https://api.sharpapi.io/api/v1
 ```
 

--- a/content/de/pricing.mdx
+++ b/content/de/pricing.mdx
@@ -141,7 +141,7 @@ Benötigen Sie höhere Limits, individuelle Funktionen oder ein SLA? Kontaktiere
 
 Alle API-Anfragen werden pro API-Schlüssel rate-limitiert. Rate-Limit-Header werden in jeder Antwort mitgeliefert:
 
-```
+```http
 X-RateLimit-Limit: 300
 X-RateLimit-Remaining: 299
 X-RateLimit-Reset: 1703123460

--- a/content/de/quickstart.mdx
+++ b/content/de/quickstart.mdx
@@ -10,7 +10,7 @@ Starten Sie mit SharpAPI in 2 Minuten.
 
 ## Basis-URL
 
-```
+```text
 https://api.sharpapi.io/api/v1
 ```
 

--- a/content/en/authentication.mdx
+++ b/content/en/authentication.mdx
@@ -66,7 +66,7 @@ See [Pricing](/en/pricing) for full details.
 
 Rate limits are enforced per API key. Current limits are returned in response headers:
 
-```
+```http
 X-RateLimit-Limit: 300
 X-RateLimit-Remaining: 299
 X-RateLimit-Reset: 1705804800

--- a/content/en/index.mdx
+++ b/content/en/index.mdx
@@ -16,7 +16,7 @@ SharpAPI is a real-time sports betting odds aggregation platform that provides:
 
 ## Base URL
 
-```
+```text
 https://api.sharpapi.io/api/v1
 ```
 

--- a/content/en/pricing.mdx
+++ b/content/en/pricing.mdx
@@ -141,7 +141,7 @@ Need higher limits, custom features, or an SLA? Contact us for enterprise pricin
 
 All API requests are rate limited per API key. Rate limit headers are included in every response:
 
-```
+```http
 X-RateLimit-Limit: 300
 X-RateLimit-Remaining: 299
 X-RateLimit-Reset: 1703123460

--- a/content/en/quickstart.mdx
+++ b/content/en/quickstart.mdx
@@ -10,7 +10,7 @@ Get started with SharpAPI in 2 minutes.
 
 ## Base URL
 
-```
+```text
 https://api.sharpapi.io/api/v1
 ```
 

--- a/content/es/authentication.mdx
+++ b/content/es/authentication.mdx
@@ -66,7 +66,7 @@ Consulta la página de [Precios](/es/pricing) para más detalles.
 
 Los límites de tasa se aplican por clave de API. Los límites actuales se devuelven en las cabeceras de respuesta:
 
-```
+```http
 X-RateLimit-Limit: 300
 X-RateLimit-Remaining: 299
 X-RateLimit-Reset: 1705804800

--- a/content/es/index.mdx
+++ b/content/es/index.mdx
@@ -16,7 +16,7 @@ SharpAPI es una plataforma de agregación de cuotas de apuestas deportivas en ti
 
 ## URL base
 
-```
+```text
 https://api.sharpapi.io/api/v1
 ```
 

--- a/content/es/pricing.mdx
+++ b/content/es/pricing.mdx
@@ -141,7 +141,7 @@ El WebSocket add-on requiere una suscripción de pago. El plan Free no admite st
 
 Todas las solicitudes a la API tienen un rate limit por API key. Las cabeceras de rate limit se incluyen en cada respuesta:
 
-```
+```http
 X-RateLimit-Limit: 300
 X-RateLimit-Remaining: 299
 X-RateLimit-Reset: 1703123460

--- a/content/es/quickstart.mdx
+++ b/content/es/quickstart.mdx
@@ -10,7 +10,7 @@ Empieza a usar SharpAPI en 2 minutos.
 
 ## URL base
 
-```
+```text
 https://api.sharpapi.io/api/v1
 ```
 

--- a/content/pt-BR/authentication.mdx
+++ b/content/pt-BR/authentication.mdx
@@ -66,7 +66,7 @@ Veja [Preços](/pt-BR/pricing) para detalhes completos.
 
 Os limites de taxa são aplicados por chave de API. Os limites atuais são retornados nos cabeçalhos de resposta:
 
-```
+```http
 X-RateLimit-Limit: 300
 X-RateLimit-Remaining: 299
 X-RateLimit-Reset: 1705804800

--- a/content/pt-BR/index.mdx
+++ b/content/pt-BR/index.mdx
@@ -16,7 +16,7 @@ A SharpAPI é uma plataforma de agregação de odds de apostas esportivas em tem
 
 ## URL Base
 
-```
+```text
 https://api.sharpapi.io/api/v1
 ```
 

--- a/content/pt-BR/pricing.mdx
+++ b/content/pt-BR/pricing.mdx
@@ -141,7 +141,7 @@ Precisa de limites maiores, recursos customizados ou um SLA? Entre em contato pa
 
 Todas as requisições à API são limitadas por taxa por API key. Os cabeçalhos de rate limit são incluídos em cada resposta:
 
-```
+```http
 X-RateLimit-Limit: 300
 X-RateLimit-Remaining: 299
 X-RateLimit-Reset: 1703123460

--- a/content/pt-BR/quickstart.mdx
+++ b/content/pt-BR/quickstart.mdx
@@ -10,7 +10,7 @@ Comece a usar a SharpAPI em 2 minutos.
 
 ## URL Base
 
-```
+```text
 https://api.sharpapi.io/api/v1
 ```
 


### PR DESCRIPTION
## Summary

PostHog recorded ~10 occurrences of \`Error: Invalid language tag: \` on \`docs.sharpapi.io/\` + \`docs.sharpapi.io/en\` over a 7-day window. Issue 3 in [sharpapi-site #83](https://github.com/Mlaz-code/sharpapi-site/issues/83) traced it to MDX code blocks opened with a bare ` ``` ` — Prism throws when asked to highlight with an empty string tag.

## Fix

The four top-level documentation pages that render at the root URLs had one empty fence each. Tagged each with the appropriate language:

| File | Block content | Language |
|---|---|---|
| `index.mdx` | API base URL | `text` |
| `quickstart.mdx` | API base URL | `text` |
| `pricing.mdx` | HTTP response headers (X-RateLimit-*) | `http` |
| `authentication.mdx` | HTTP response headers (X-RateLimit-*) | `http` |

Applied to all four locales (en / de / pt-BR / es) — same fence positions across all locales because the code content is literal (URLs + HTTP headers don't translate). **16 edits total** (4 files × 4 locales × 1 fence each).

## Scope explicitly NOT covered

The broader audit shows 436 opening fences with no language tag across 176 MDX files in deeper content paths (`/concepts`, `/api-reference`, `/streaming`, etc.). Those don't currently produce throws visible to customers (Prism falls back to no-highlight when both `bash` + `python` language modules are absent, only throws on the specific empty-string-tag path the top-level pages hit). Full audit is a separate follow-up scoped to the broader content tree.

## Build verification

\`\`\`
[Reading languages]    Discovered 4 languages: pt-br, en, de, es
[Building search indexes]  Indexed 4 languages / 212 pages / 15076 words
Finished in 8.966 seconds
\`\`\`

## Test plan

- [ ] Vercel preview deploy renders index / pricing / quickstart / authentication on all 4 locales without console errors
- [ ] PostHog `Error: Invalid language tag` count for `docs.sharpapi.io/` + `docs.sharpapi.io/en` drops to ~0 in the 24h post-deploy window (was averaging ~1.5/day on the affected pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)