### PR TITLE
docs(api-reference): document connection reuse + HTTP/3 + X-Cache-Status

### DIFF
--- a/content/en/api-reference/overview.mdx
+++ b/content/en/api-reference/overview.mdx
@@ -229,9 +229,43 @@ Every API response includes these headers:
 | `X-RateLimit-Reset` | `1705804800` | Unix timestamp when the rate limit resets |
 | `X-Data-Delay` | `0` | Data delay in seconds (`60` for Free, `0` for paid tiers) |
 | `X-Request-Id` | `req_a1b2c3d4` | Unique request identifier for debugging and support |
+| `X-Cache-Status` | `HIT` | Edge-cache state for this response (`HIT`, `MISS`, `STALE`, `BYPASS`). `STALE` means the edge briefly served slightly outdated content while revalidating against the origin — expected during transient origin slowness, not an error |
+| `Alt-Svc` | `h3=":443"; ma=86400` | Indicates HTTP/3 (QUIC) is available on this host. Clients that opt in skip the TCP + TLS handshake on subsequent connections — see [Connection Reuse](#connection-reuse) below |
 
 <Callout type="info">
 Include the `X-Request-Id` value when contacting support about a specific request.
+</Callout>
+
+## Connection Reuse
+
+For polling clients, the dominant cost on a *fresh* connection to `api.sharpapi.io` is the TLS handshake — typically 150–200 ms — not the API server itself, which returns in ~40–50 ms once TCP + TLS are up. Reusing a single TLS connection across requests collapses subsequent calls to roughly the server-side TTFB.
+
+```bash
+# Fresh connection — first request pays full TCP + TLS:
+curl -o /dev/null -s \
+  -w "ssl=%{time_appconnect}s ttfb=%{time_starttransfer}s total=%{time_total}s\n" \
+  -H "X-API-Key: $SHARPAPI_KEY" \
+  https://api.sharpapi.io/api/v1/gamestate/baseball
+# → ssl=0.16s ttfb=0.20s total=0.20s
+
+# Two URLs in one curl call — the second reuses the open connection:
+curl -o /dev/null -s \
+  -w "ssl=%{time_appconnect}s ttfb=%{time_starttransfer}s total=%{time_total}s\n" \
+  -H "X-API-Key: $SHARPAPI_KEY" \
+  https://api.sharpapi.io/api/v1/gamestate/baseball \
+  https://api.sharpapi.io/api/v1/gamestate/tennis
+# → ssl=0.00s ttfb=0.04s total=0.04s
+```
+
+### Recommendations
+
+- **HTTP/1.1 keep-alive is the default** in `curl`, Python `httpx` / `requests.Session()`, `aiohttp`, Node `fetch` / `axios` / `undici`, Go `http.Client`, OkHttp, and most other modern clients. Reuse a single client/session across calls — don't construct a new client per request.
+- **HTTP/2 connection coalescing** multiplexes many concurrent requests over one connection to the same host. Enabled by default in HTTP/2-capable clients.
+- **HTTP/3 (QUIC)** is offered via `Alt-Svc: h3=":443"`. Clients that opt in (`curl --http3`, `httpx[http2,http3]`, Node `undici` with `allowH2: true`) skip the TCP handshake entirely on subsequent connections. Worthwhile for cold-start workloads such as serverless functions.
+- **For real-time data, use streaming.** The [`/api/v1/stream`](/en/api-reference/stream) endpoint keeps a single connection open and pushes deltas as they happen — no per-request handshake at all.
+
+<Callout type="info">
+For a polling client hitting `/api/v1/odds` once per second, the TLS cost amortizes to ~0 after the first request. The 150 ms handshake matters most for serverless / short-lived clients that close the connection between calls.
 </Callout>
 
 ## Tier Comparison


### PR DESCRIPTION
## Summary

Captures the recommendations from [`Mlaz-code/sharp-api-go#113`](https://github.com/Mlaz-code/sharp-api-go/issues/113) — a TLS-handshake-dominates-latency finding the original reporter explicitly marked as informational/documentation-only.

Re-probed on 2026-05-17 against `api.sharpapi.io/api/v1/gamestate/*`:

| Mode | SSL | TTFB | Total |
|---|---|---|---|
| Fresh connection | 0.16 s | 0.20 s | 0.20 s |
| Reused connection (2nd hop in same curl) | 0.00 s | 0.04 s | 0.04 s |

Findings hold. `Alt-Svc: h3=":443"; ma=86400` still advertised. `X-Cache-Status` sampling now shows `MISS` on cold paths and `HIT` on rapid succession — `STALE` is the (expected) stale-while-revalidate state during transient origin slowness; not seen in 10 probes today.

## What's in this PR

- New **"Connection Reuse"** section in `content/en/api-reference/overview.mdx` between Standard Response Headers and Tier Comparison. Two `curl` examples (fresh vs reused), a short Recommendations bullet list (HTTP/1.1 keep-alive defaults, HTTP/2 multiplexing, HTTP/3 via Alt-Svc, streaming for real-time).
- Two new rows in the **Standard Response Headers** table for `X-Cache-Status` (`HIT`/`MISS`/`STALE`/`BYPASS` semantics + clarification that `STALE` is expected, not an error) and `Alt-Svc`.
- EN-only — translation to de / es / pt-BR can follow the prior batch pattern (PR #225 / #226 were also EN-only).

## Verification

- `pnpm install` + `npm run build`: 213 pages compile across all 4 locales (212 before + this new section anchor) — clean exit. Pagefind indexed 15,212 words.
- `npm run typecheck`: pass.
- Anchor `[Connection Reuse](#connection-reuse)` resolves to the new `## Connection Reuse` heading on the same page (same pattern used at line 218 in the existing doc).
- Cross-page link `/en/api-reference/stream` matches existing convention (used in `opportunities-low-hold.mdx`, `conventions.mdx`, etc.).

## Test plan

- [ ] CI build passes
- [ ] Render check on Vercel preview: section appears between "Standard Response Headers" and "Tier Comparison"
- [ ] Anchor link `#connection-reuse` jumps correctly
- [ ] After merge: close `sharp-api-go#113` citing this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)