### PR TITLE
docs(streaming): track rows by stable id, not composite key

### DIFF
--- a/content/en/streaming/overview.mdx
+++ b/content/en/streaming/overview.mdx
@@ -142,6 +142,24 @@ es.addEventListener('odds:update', (e) => {
 });
 ```
 
+<Callout type="warning">
+**Track rows by `id`, not by a composite key.**
+
+The `id` field on every snapshot row and every `odds:update` delta is the **stable identifier for that (event, sportsbook, market, selection) tuple** — it does **not** change when the line moves. For asian-handicap / team-total / over-under markets, the `line` field updates in place under the same `id`, so building a composite key like `(event_id, market_type, selection, line)` makes your local map miss every line-change.
+
+```js
+// ✗ Wrong — composite key breaks on line updates (e.g. asian_handicap -0.5 → -0.75
+//   produces a different composite key, and your tracking map loses the row)
+const key = `${o.event_id}|${o.market_type}|${o.selection}|${o.line ?? ''}`
+oddsMap.set(key, o)
+
+// ✓ Right — `id` is stable across line updates
+oddsMap.set(o.id, o)
+```
+
+This affects asian-handicap, team-total, over/under, and any market where the line can move. Moneyline / win-only markets have `line=null` so composite keys happen to work for them — but the bug only surfaces the moment your client subscribes to a line-bearing market.
+</Callout>
+
 ### Python
 
 ```python


### PR DESCRIPTION
Type: docs

Refs Mlaz-code/sharp-api-go#165

## Why

A paying customer (Sharp + WebSocket addon, \$498/mo) reported that asian-handicap and team-total markets were "returning wrong information." Investigation traced it to a **client-side bug**: their bot was constructing a composite tracking key that included \`line\`, so when Pinnacle nudged an asian_handicap from -0.5 to -0.75 the new delta's composite key didn't match the cached one and the move-calculation fell back to comparing against the snapshot baseline instead of the most recent same-line price. The bug stayed invisible on moneyline (\`line=null\` so the composite key was effectively just the row's other fields) but surfaced on every line-bearing market.

Our server side is correct. Our row schemas are correct. The wiring example in our docs even shows the canonical pattern (\`oddsMap.set(odd.id, odd)\` + \`oddsMap.get(delta.id)\`). But the canonical pattern was never explicitly called out as a **guard** — and developers reading the example are free to substitute their own composite key, which is what happened.

## What

Adds a \`<Callout type="warning">\` under the JavaScript SSE example in \`content/en/streaming/overview.mdx\`. Contains:

- One-line rule: track by \`id\`, not by composite.
- A two-block comparison (\`✗ Wrong\` composite-key recipe + \`✓ Right\` \`id\`-keyed recipe), showing the exact failure mode (asian_handicap -0.5 → -0.75 making the composite key shift).
- An explanation of why moneyline / win-only markets happen to work by accident — and why the bug only surfaces the moment the client subscribes to a line-bearing market.

## Scope

**English only.** The de / es / pt-BR streaming pages are partially translated (each is ~18 lines shorter than English even before this change), so the callout will need a translation pass on its own — keeping this PR atomic for the docs review.

## Test plan

- [x] \`npm run build\` clean — site builds across 4 locales (en, de, pt-BR, es), 214 pages indexed by pagefind
- [x] Callout uses the same Nextra import (\`import { Callout, Tabs } from 'nextra/components'\`) already at line 5 of the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)