### PR TITLE
fix(i18n): add missing locale translations + fix asyncapi.yaml links

### DIFF
--- a/content/de/api-reference/conventions.mdx
+++ b/content/de/api-reference/conventions.mdx
@@ -9,7 +9,7 @@ import { Callout } from 'nextra/components'
 SharpAPI liefert vorhersehbare Antwortstrukturen über jeden REST-Endpoint hinweg. Diese Seite kodifiziert diese Konventionen, damit Sie generische Parser bauen können statt Sonderfälle pro Endpoint.
 
 <Callout type="info">
-  Diese Seite beschreibt die REST-Konventionen. SSE-Streams werden in [SSE Stream](/de/api-reference/stream) behandelt, und das bidirektionale WebSocket-Protokoll hat seine eigene [AsyncAPI 3.0 Spezifikation](/asyncapi.yaml).
+  Diese Seite beschreibt die REST-Konventionen. SSE-Streams werden in [SSE Stream](/de/api-reference/stream) behandelt, und das bidirektionale WebSocket-Protokoll hat seine eigene [AsyncAPI 3.0 Spezifikation](https://docs.sharpapi.io/asyncapi.yaml).
 </Callout>
 
 ## HTTP-Statuscodes, keine Envelopes
@@ -192,6 +192,6 @@ ETag: "9dc023776c4b382"
 ## Maschinenlesbare Quelle der Wahrheit
 
 - REST-Oberfläche: [`openapi.json`](/openapi.json) (OpenAPI 3.1)
-- WebSocket-Oberfläche: [`asyncapi.yaml`](/asyncapi.yaml) (AsyncAPI 3.0)
+- WebSocket-Oberfläche: [`asyncapi.yaml`](https://docs.sharpapi.io/asyncapi.yaml) (AsyncAPI 3.0)
 
 Beide Dateien werden als statische Assets veröffentlicht und können in CI verglichen werden. Wenn diese Seite von der Spezifikation abweicht, gewinnt die Spezifikation — die Spezifikation wird vom bereitgestellten Server generiert.

--- a/content/de/concepts/_meta.js
+++ b/content/de/concepts/_meta.js
@@ -3,6 +3,8 @@ export default {
   "ev-calculation": "EV-Berechnung",
   arbitrage: "Arbitrage",
   "event-matching": "Event-Zuordnung",
+  "entity-reference-ids": "Entitätsreferenz-IDs",
   "live-vs-prematch": "Live vs. Pre-Match",
   "pinnacle-odds-changed-at": "Pinnacle `odds_changed_at`",
+  "polymarket-resolution": "Polymarket-Auflösung",
 }

--- a/content/de/concepts/entity-reference-ids.mdx
+++ b/content/de/concepts/entity-reference-ids.mdx
@@ -1,0 +1,144 @@
+---
+description: "Entitäts-Referenz-IDs — numerical_id-Semantik, verschachtelte Team/Sport/Liga/Market/Sportsbook-Objekte und deren Verwendung für Joins, Indizierung und Cross-Feed-Mapping."
+---
+
+import { Callout } from 'nextra/components'
+
+# Entitäts-Referenz-IDs
+
+SharpAPI gibt stabile, ganzzahlig-kodierte Bezeichner (`numerical_id`) für jede Referenzentität aus, sowie selbstbeschreibende verschachtelte Referenzobjekte für jede Odds-Zeile und jedes Opportunity-Leg. Diese Seite dokumentiert, was diese IDs garantieren, wie sie verwendet werden und wie sie mit den bestehenden String-IDs zusammenhängen.
+
+<Callout type="info">
+  **Neu (Mai 2026).** Sowohl `numerical_id` als auch die verschachtelten Referenzobjekte sind **additiv**. Bestehende String-IDs (`sport: "baseball"`, `league: "mlb"`, `sportsbook: "pinnacle"`, `home_team: "New York Yankees"`) bleiben in jeder Antwort erhalten und sind nicht veraltet. Es gibt keinen Zeitplan für deren Entfernung — beide Formen werden dauerhaft unterstützt.
+</Callout>
+
+## Was ist neu
+
+Jeder Referenz-Endpoint (`/sports`, `/leagues`, `/sportsbooks`, `/markets`, `/teams`) gibt jetzt zusätzlich zur bestehenden Slug-`id` einen `numerical_id`-Ganzzahlwert zurück. `/teams` gibt zusätzlich ein `abbreviation`-Feld zurück, sofern bekannt.
+
+Jede Odds-Zeile (und jedes Leg einer EV- / Arbitrage- / Middle-Opportunity) enthält nun sechs optionale **verschachtelte Referenzobjekte**, die `id`, Anzeigename und `numerical_id` der Entität direkt mit der Zeile bündeln — ohne zusätzliche Abfrage gegen `/sports` oder `/teams`:
+
+```json
+{
+  "home": {
+    "id": "new_york_yankees",
+    "numerical_id": 20,
+    "name": "New York Yankees",
+    "abbreviation": "NYY",
+    "logo": "https://cdn.opticodds.com/team-logos/baseball/36.png",
+    "city": "New York",
+    "mascot": "Yankees",
+    "conference": "AL",
+    "division": "East Division"
+  },
+  "away": {
+    "id": "boston_red_sox",
+    "numerical_id":  5,
+    "name": "Boston Red Sox",
+    "abbreviation": "BOS",
+    "logo": "https://cdn.opticodds.com/team-logos/baseball/14.png",
+    "city": "Boston",
+    "mascot": "Red Sox",
+    "conference": "AL",
+    "division": "East Division"
+  },
+  "sport_ref":      { "id": "baseball",         "numerical_id":  3, "name": "Baseball" },
+  "league_ref":     { "id": "mlb",              "numerical_id": 354, "label": "MLB" },
+  "market_ref":     { "id": "moneyline",        "numerical_id": 878, "label": "Moneyline" },
+  "sportsbook_ref": { "id": "pinnacle",         "numerical_id":  28, "label": "Pinnacle" }
+}
+```
+
+## `numerical_id`-Semantik
+
+Jede `numerical_id` wird aus einem einmal festgelegten, domänenspezifischen Registry unter `api-adapters/sharp_atlas/` vergeben. Der Vertrag lautet:
+
+| Eigenschaft | Garantie |
+|---|---|
+| **Eingefroren** | Einmal vergeben, wird eine `numerical_id` niemals wiederverwendet, neu ausgestellt oder einer anderen Entität zugeordnet. Die `numerical_id: 20` der Yankees bleibt `20`, bis die API eingestellt wird. |
+| **Dicht ab 1** | IDs beginnen bei `1` und werden sequenziell pro Domäne vergeben. Es gibt keine negativen oder null-IDs und keine großen Lücken. Sports, Ligen, Sportsbooks, Markets und Teams haben jeweils einen eigenen dichten Bereich. |
+| **Domänen-begrenzt** | Eine `numerical_id` ist nur innerhalb ihrer Domäne (Sport, Liga, Sportsbook, Market, Team) eindeutig. `numerical_id: 3` bei einem Sport hat keinen Bezug zu `numerical_id: 3` bei einem Team. Zur Unterscheidung muss die Ganzzahl mit der Domäne kombiniert werden. |
+| **Vergeben, nicht abgeleitet** | IDs werden explizit in den Atlas-JSONs verfolgt — sie sind keine Hashes des Slugs und werden nicht aus der Sortierreihenfolge berechnet. Das Hinzufügen einer neuen Entität vergibt die nächste freie Ganzzahl; das Umbenennen eines Slugs ändert dessen `numerical_id` nicht. |
+| **Keine Sportsbook-ID** | Dies ist SharpAPIs Bezeichner, nicht die interne des Sportsbooks. Die nativen Event-/Market-/Selection-IDs eines Bookmakers werden weiterhin zeilenweise ausgegeben — siehe `external_event_id`, `selection_id`, `market_id` und `external_ids` am [Events](/de/api-reference/events)-Endpoint. |
+
+## Wenn Felder fehlen
+
+Die verschachtelten Referenzobjekte werden **nur ausgegeben, wenn die zugrundeliegende Entität im Atlas gemappt wurde**. Bei nicht gemappten Entitäten — typischerweise Long-Tail-Ligen, exotische Markets oder neu hinzugefügte Sportsbooks vor der Katalogzuweisung — wird der entsprechende `*_ref`-Block weggelassen (oder hat `numerical_id: null`), und das vorhandene String-Feld in der Zeile ist die einzige sichtbare ID.
+
+In der Praxis:
+
+- Wichtige Sports, Ligen und Books sind vollständig gemappt — jeder `*_ref`-Block ist zu erwarten.
+- Player-Prop-Markets und Ecken/Karten/Perioden-Markets im Fußball haben den breitesten Katalog; einige Nischen-Prop-Typen werden noch zugewiesen.
+- Team-`abbreviation` ist dort befüllt, wo ein Kürzel allgemein bekannt ist (US-Major-Ligen, EPL, ATP/WTA-Kürzel). Bei kleineren / internationalen Teams kann es fehlen.
+
+Konsumenten sollten jeden verschachtelten Block als **optional** behandeln. Generische Clients sollten auf das flache String-Feld (`sport`, `league`, `sportsbook`, `home_team`, `away_team`, `market_type`) zurückfallen, wenn der entsprechende `*_ref` nicht vorhanden ist.
+
+## Empfohlene Verwendung
+
+### Indizierung & Joins
+Verwende `numerical_id` als Primärschlüssel beim Speichern von Odds/Opportunities in deiner eigenen Datenbank. Ganzzahlschlüssel sind kleiner, günstiger zu indizieren und bleiben stabil bei Slug-Umbenennungen oder Änderungen von Anzeigenamen.
+
+### Cross-Feed-Mapping
+Wenn du von mehreren Datenanbietern importierst, bietet `numerical_id` eine schnelle Gleichheitsprüfung innerhalb von SharpAPI-Zeilen. Für das Mapping **über** Anbieter hinweg ist der Slug-`id` nach wie vor der portablere Join-Schlüssel — Slugs sind lesbar und tendieren dazu, sich über Anbieter hinweg stärker zu überschneiden als Ganzzahl-IDs.
+
+### UI-Anzeige
+Verwende `name` (Sports, Teams) oder `label` (Ligen, Markets, Sportsbooks) zur Anzeige; `abbreviation` bei `home`/`away` eignet sich für kompakte Zellen.
+
+### Streaming
+Dieselben verschachtelten Objekte erscheinen auf `/api/v1/stream/odds` SSE-Frames und auf WebSocket v1 / v1.5 Odds-Payloads — kein separater Stream ist erforderlich.
+
+## Feldreferenz
+
+### Referenz-Endpoints
+
+Jeder Referenz-Endpoint fügt seinem bestehenden Objektschema `numerical_id` hinzu. `/teams` fügt zusätzlich `abbreviation` hinzu.
+
+| Endpoint | Hinzugefügtes Feld | Typ | Hinweise |
+|---|---|---|---|
+| [`/sports`](/de/api-reference/sports) | `numerical_id` | integer \| null | Sport-begrenzte Domäne |
+| [`/leagues`](/de/api-reference/leagues) | `numerical_id` | integer \| null | Liga-begrenzte Domäne |
+| [`/sportsbooks`](/de/api-reference/sportsbooks) | `numerical_id` | integer \| null | Sportsbook-begrenzte Domäne |
+| [`/markets`](/de/api-reference/markets) | `numerical_id` | integer \| null | Market-Typ-begrenzte Domäne |
+| [`/teams`](/de/api-reference/teams) | `numerical_id`, `abbreviation`, `logo`, `city`, `mascot`, `conference`, `division` | integer \| null, string \| null | Team-begrenzte Domäne. Die letzten fünf sind Atlas-Metadaten aus OpticOdds. |
+
+### Verschachtelte Referenzblöcke bei Odds & Opportunity-Legs
+
+| Block | Wo | Felder | Zweck |
+|---|---|---|---|
+| `home`, `away` | Jede Odds-Zeile, jedes Opportunity-Leg | `id`, `numerical_id`, `name`, `abbreviation`, `logo`, `city`, `mascot`, `conference`, `division` | Löst die beiden Kontrahenten ohne separaten `/teams`-Aufruf auf. |
+| `sport_ref` | Wie oben | `id`, `numerical_id`, `name` | Anzeigebereiter Sport-Verweis. |
+| `league_ref` | Wie oben | `id`, `numerical_id`, `label` | Anzeigebereiter Liga-Verweis. |
+| `market_ref` | Wie oben | `id`, `numerical_id`, `label` | Anzeigebereiter Market-Verweis (kanonischer Market-Typ). |
+| `sportsbook_ref` | Wie oben | `id`, `numerical_id`, `label` | Anzeigebereiter Sportsbook-Verweis. |
+
+Alle inneren Felder sind **optional** innerhalb eines Blocks. Ein Block kann mit einer `null`-`numerical_id` vorhanden sein, wenn der Slug gemappt wurde, die Ganzzahlzuweisung aber noch aussteht; sowohl `numerical_id` als auch der gesamte Block können bei nicht gemappten Entitäten fehlen.
+
+### Team-Metadatenfelder
+
+Die `home`- / `away`-Blöcke enthalten fünf zusätzliche optionale Metadatenfelder über `id` / `numerical_id` / `name` / `abbreviation` hinaus. Sie stammen aus dem SharpAPI-Atlas und sind für die große Mehrheit der Teams befüllt (ca. 93 % bei `logo`, mit vergleichbarer Abdeckung für den Rest):
+
+| Feld | Beispiel | Hinweise |
+|---|---|---|
+| `logo` | `"https://cdn.opticodds.com/team-logos/baseball/36.png"` | Vollständige CDN-URL für ein Team-Wappen. Behandle den Host als undurchsichtig; SharpAPI kann dasselbe Asset in Zukunft unter seiner eigenen Domain neu hosten. |
+| `city` | `"New York"` | Der geografische Ankerpunkt des Teams. Bei Teams mit mehreren Städten (z. B. die New York Football Giants, die in NJ spielen) folgen wir der konventionellen Bezeichnung der Liga. |
+| `mascot` | `"Yankees"` | Das Maskottchen / der Spitznamensteil des vollständigen Namens. |
+| `conference` | `"AL"`, `"AFC"`, `"Western"` | Liga-definierte Konferenz / Gruppierung. Format variiert je Liga. |
+| `division` | `"East Division"`, `"NL East"`, `"Pacific Division"` | Untergruppierung innerhalb der Konferenz, liga-definiert. |
+
+Einzelsport-Teilnehmer (Tennisspieler, MMA-Kämpfer, Golfer, Fahrer) haben diese Felder in der Regel nicht befüllt — sie sind keine "Teams" im konventionellen Sinne und erben nur `id` / `numerical_id` / `name`.
+
+## Migration
+
+Es gibt nichts zu migrieren. Fahre mit den flachen String-Feldern fort, wenn sie deinen Bedarf decken. Übernimm die `*_ref`-Blöcke und `numerical_id` selektiv, wenn:
+
+- du einen stabilen Ganzzahlschlüssel für die Speicherung benötigst,
+- du anzeigebereite Labels ohne einen zweiten API-Aufruf möchtest,
+- oder du eine Cross-Feed-Normalisierungsschicht aufbaust.
+
+Die flachen Felder und die verschachtelten Blöcke beschreiben dieselbe Zeile — sie werden sich nicht widersprechen.
+
+## Verwandte Themen
+
+- [Sports](/de/api-reference/sports), [Leagues](/de/api-reference/leagues), [Sportsbooks](/de/api-reference/sportsbooks), [Markets](/de/api-reference/markets), [Teams](/de/api-reference/teams) — Referenz-Endpoints mit dem neuen `numerical_id`-Feld
+- [Odds Snapshot](/de/api-reference/odds), [+EV Opportunities](/de/api-reference/opportunities-ev), [Arbitrage](/de/api-reference/opportunities-arbitrage), [Middles](/de/api-reference/opportunities-middles) — Endpoints mit verschachtelten Referenzblöcken
+- [Event Matching](/de/concepts/event-matching) — wie SharpAPI dasselbe Spiel über verschiedene Books hinweg zusammenführt

--- a/content/de/concepts/polymarket-resolution.mdx
+++ b/content/de/concepts/polymarket-resolution.mdx
@@ -1,0 +1,98 @@
+---
+title: "Polymarket Auflösungsstatus"
+description: "Wie SharpAPI den UMA Optimistic-Oracle-Auflösungslebenszyklus auf Polymarket-Märkten abbildet — abgerechnet, storniert, bestritten, vorgeschlagen."
+---
+
+import { Callout } from 'nextra/components'
+
+# Polymarket Auflösungsstatus
+
+Polymarket ist ein Vorhersagemarkt-CLOB, dessen Märkte durch das [UMA Optimistic Oracle](https://docs.uma.xyz/) bewertet werden, nicht durch einen Sportsbook-Trading-Desk. Wenn Sie Polymarket-Quoten über SharpAPI abrufen, kann die Zeile ein zusätzliches Feld enthalten — `polymarket_resolution` — das angibt, wo sich dieser Markt im UMA-Auflösungslebenszyklus befindet.
+
+Dieses Feld ist **nur für Polymarket** verfügbar. Andere Sportsbook-Zeilen (Pinnacle, DraftKings, FanDuel, usw.) enthalten es nicht, da ihre vorgelagerten Wire-Formate kein entsprechendes Signal ausgeben. Siehe [Pinnacle Wire-Analyse](https://github.com/Mlaz-code/api-adapters/) für die parallele Untersuchung, die zu dem Schluss gelangte, dass dasselbe Feld für traditionelle Bücher nicht bereitgestellt werden kann.
+
+## Wann das Feld erscheint
+
+| Marktstatus | `polymarket_resolution` |
+|---|---|
+| Aktiv im Handel | weggelassen (Feld nicht vorhanden) |
+| Geschlossen, mit einem Gewinner aufgelöst | `"settled_normal"` |
+| Geschlossen, storniert / rückerstattet | `"voided"` |
+| Geschlossen, UMA-Einspruch läuft | `"disputed"` |
+| Geschlossen, UMA-Vorschlag eingereicht, Einspruchsfenster offen | `"proposed"` |
+| Geschlossen, Lebenszyklus-Felder leer (Legacy-Markt) | `"unknown"` |
+| Kein Polymarket-Buch | weggelassen |
+
+Das Feld ist **additiv**. Bestehende Parser, die unbekannte Felder ignorieren, funktionieren weiterhin unverändert.
+
+## Wertsemantik
+
+### `settled_normal`
+
+Das UMA-Oracle hat ein Gewinnergebnis erklärt. Bei einem binären Markt wurde genau ein Ergebnis zu `$1.00` aufgelöst und das andere zu `$0.00`. Dies ist der typische Endzustand.
+
+```json
+{
+  "sportsbook": "polymarket",
+  "marketType": "binary",
+  "selection": "Yes",
+  "odds": -10000,
+  "polymarket_resolution": "settled_normal",
+  "trueProbability": 1.0
+}
+```
+
+### `voided`
+
+Das UMA-Oracle hat den Markt storniert — beide binären Ergebnisse wurden zu `$0.50` aufgelöst ("alle erstatten"). Dies ist dieselbe Wire-Signatur für alle folgenden Fälle:
+
+- Ein abgesagtes Spiel (Sportereignis abgesagt oder abgebrochen)
+- Ein Teilnehmer zieht sich vor dem Ereignis zurück
+- Das Ereignis findet nicht statt (z. B. "Karte 3 Gewinner", wenn die Serie in 2 Karten endete)
+- Jede andere durch UMA festgestellte Stornierung
+
+<Callout type="warning">
+**Polymarket unterscheidet nicht, *warum* ein Markt storniert wurde.** Der menschenlesbare Grund liegt im Off-Chain-UMA-Einspruchs-Thread auf dem UMA-Oracle-Frontend, nicht in der Polymarket-API. Wenn Ihre Anwendung zwischen Absage, Rückzug und Nicht-Stattfinden unterscheiden muss, können diese Informationen nicht aus Polymarks Wire bezogen werden — Sie müssten den UMA-Einspruchstext direkt lesen.
+
+Dies ist eine bewusste Designentscheidung der UMA-Optimistic-Oracle-Architektur, keine SharpAPI-Auslassung. Wir haben uns entschieden, `voided` als einzelnen Bucket darzustellen, anstatt aus Heuristiken zu raten — gemäß unserer [Keine-Inferenz-Richtlinie](https://github.com/Mlaz-code/api-adapters/): Wenn das Upstream mehrdeutig ist, raten wir nicht.
+</Callout>
+
+### `disputed`
+
+Der UMA-Vorschlagende hat eine Auflösung eingereicht, die angefochten wurde. Der Markt befindet sich nun in einer UMA-Token-Inhaber-Abstimmung, typischerweise 48 Stunden. Die endgültige Auflösung wird nach Abschluss der Abstimmung schließlich `settled_normal` oder `voided` werden.
+
+### `proposed`
+
+Der UMA-Vorschlagende hat eine Kandidatenauflösung eingereicht; das Einspruchsfenster ist offen (typischerweise 2 Stunden). Der Markt wird zu `settled_normal` / `voided` übergehen, sobald das Fenster unangefochten schließt, oder zu `disputed`, falls ein Einspruch erhoben wird.
+
+### `unknown`
+
+Der Markt ist geschlossen, aber die UMA-Lebenszyklus-Felder sind leer. Dies geschieht bei älteren Polymarket-Märkten, die vor dem UMA-Status-Tracking entstanden sind, oder in seltenen Grenzfällen, bei denen die Gamma-API den Lebenszyklus-Verlauf nicht zurückgibt. Das Feld ist `unknown` statt zu raten.
+
+## Verzögerte Auflösung
+
+Polymarket-Märkte können sich Tage oder Wochen nach dem Ende des zugrundeliegenden Ereignisses auflösen. Das Feld `polymarket_resolution` erscheint, sobald der vorgelagerte Auflösungslebenszyklus voranschreitet, auch lange nach dem Schließen des Marktes.
+
+Wenn Ihre Anwendung Auflösungsereignisse verarbeitet (zur Bewertung, Abrechnungsabgleich usw.), beobachten Sie den SSE-Stream / WebSocket für diese spät eintreffenden Zeilen.
+
+## Vergleich mit anderen Büchern
+
+| Buch | Entsprechendes Feld? | Hinweise |
+|---|---|---|
+| **Polymarket** | `polymarket_resolution` | 5-Status-Enum, abgeleitet vom UMA-Oracle |
+| **Kalshi** | _(noch nicht)_ | Kalshi hat Abrechnungsereignisse, aber wir stellen sie heute nicht bereit — separate Anfrage |
+| **Pinnacle** | _(upstream nicht verfügbar)_ | Pinnacles Wire gibt kein Echtzeit-Grundfeld aus; `cancellationReason` existiert nur am post-grading Lines-API-Partnerendpunkt |
+| **DraftKings / FanDuel / BetMGM / Caesars** | _(nicht verfügbar)_ | Gesperrte Märkte verschwinden einfach aus dem Feed; kein Statusfeld wird ausgegeben |
+| **OpticOdds (Branchenvergleich)** | _(kein Grund)_ | Fixture-level `status: cancelled` existiert, trägt aber keinen Grund; Per-Markt-Objekte haben kein Statusfeld |
+
+Die von Datenkunden gewünschten Informationen — ein buchspezifischer Abrechnungsgrund — sind kein Branchenstandard. Polymarket ist der seltene Fall, bei dem der vorgelagerte Wire ihn tatsächlich enthält, da die UMA-Auflösung on-chain und öffentlich beobachtbar ist.
+
+## Warum das Feld mit Polymarket-Präfix versehen ist
+
+Wir haben das Feld bewusst `polymarket_resolution` statt einem generischen `resolutionStatus` genannt, damit klar ist, dass die Werte Polymarket-spezifisch sind. Eine zukünftige Kalshi-Version wäre ein separates `kalshiResolution`-Feld mit eigenem Enum — die Wire-Formate sind unterschiedlich genug, dass ein einheitliches Enum entweder dem kleinsten gemeinsamen Nenner entsprechen würde (nutzlos) oder voller Sternchen für "nur Polymarket" / "nur Kalshi"-Werte wäre.
+
+## Siehe auch
+
+- [Sportsbook-Liste — Vorhersagemärkte](/api-reference/sportsbooks#prediction-markets)
+- [Odds-API-Referenz](/api-reference/odds)
+- [Live vs. Vor dem Spiel](/de/concepts/live-vs-prematch) — behandelt die verwandte `marketStatus`-Semantik

--- a/content/en/api-reference/conventions.mdx
+++ b/content/en/api-reference/conventions.mdx
@@ -9,7 +9,7 @@ import { Callout } from 'nextra/components'
 SharpAPI returns predictable response shapes across every REST endpoint. This page codifies those conventions so you can build generic parsers, not per-endpoint special cases.
 
 <Callout type="info">
-  This page describes the REST conventions. SSE streams are covered in [SSE Stream](/en/api-reference/stream), and the bidirectional WebSocket protocol has its own [AsyncAPI 3.0 spec](/asyncapi.yaml).
+  This page describes the REST conventions. SSE streams are covered in [SSE Stream](/en/api-reference/stream), and the bidirectional WebSocket protocol has its own [AsyncAPI 3.0 spec](https://docs.sharpapi.io/asyncapi.yaml).
 </Callout>
 
 ## HTTP status codes, not envelopes
@@ -192,6 +192,6 @@ ETag: "9dc023776c4b382"
 ## Machine-readable source of truth
 
 - REST surface: [`openapi.json`](/openapi.json) (OpenAPI 3.1)
-- WebSocket surface: [`asyncapi.yaml`](/asyncapi.yaml) (AsyncAPI 3.0)
+- WebSocket surface: [`asyncapi.yaml`](https://docs.sharpapi.io/asyncapi.yaml) (AsyncAPI 3.0)
 
 Both files are published as static assets and can be diffed in CI. If this page drifts from the spec, the spec wins — the spec is generated from the deployed server.

--- a/content/es/api-reference/conventions.mdx
+++ b/content/es/api-reference/conventions.mdx
@@ -9,7 +9,7 @@ import { Callout } from 'nextra/components'
 SharpAPI devuelve estructuras de respuesta predecibles en todos los endpoints REST. Esta página recoge dichas convenciones para que puedas crear analizadores genéricos en lugar de casos especiales por endpoint.
 
 <Callout type="info">
-  Esta página describe las convenciones REST. Los flujos SSE se tratan en [Flujo SSE](/es/api-reference/stream), y el protocolo WebSocket bidireccional dispone de su propia [especificación AsyncAPI 3.0](/asyncapi.yaml).
+  Esta página describe las convenciones REST. Los flujos SSE se tratan en [Flujo SSE](/es/api-reference/stream), y el protocolo WebSocket bidireccional dispone de su propia [especificación AsyncAPI 3.0](https://docs.sharpapi.io/asyncapi.yaml).
 </Callout>
 
 ## Códigos de estado HTTP, no envoltorios
@@ -192,6 +192,6 @@ ETag: "9dc023776c4b382"
 ## Fuente de verdad legible por máquina
 
 - Superficie REST: [`openapi.json`](/openapi.json) (OpenAPI 3.1)
-- Superficie WebSocket: [`asyncapi.yaml`](/asyncapi.yaml) (AsyncAPI 3.0)
+- Superficie WebSocket: [`asyncapi.yaml`](https://docs.sharpapi.io/asyncapi.yaml) (AsyncAPI 3.0)
 
 Ambos archivos se publican como recursos estáticos y se pueden comparar en CI. Si esta página se desvía de la especificación, la especificación gana: la especificación se genera a partir del servidor desplegado.

--- a/content/es/concepts/_meta.js
+++ b/content/es/concepts/_meta.js
@@ -3,6 +3,8 @@ export default {
   "ev-calculation": "Cálculo de EV",
   arbitrage: "Arbitraje",
   "event-matching": "Emparejamiento de Eventos",
+  "entity-reference-ids": "IDs de Referencia de Entidades",
   "live-vs-prematch": "En Vivo vs. Pre-Partido",
   "pinnacle-odds-changed-at": "Pinnacle `odds_changed_at`",
+  "polymarket-resolution": "Resolución de Polymarket",
 }

--- a/content/es/concepts/entity-reference-ids.mdx
+++ b/content/es/concepts/entity-reference-ids.mdx
@@ -1,0 +1,144 @@
+---
+description: "IDs de referencia de entidades — semántica de numerical_id, objetos de referencia anidados de equipo/deporte/liga/mercado/casa de apuestas, y cómo usarlos para joins, indexación y mapeo entre feeds."
+---
+
+import { Callout } from 'nextra/components'
+
+# IDs de referencia de entidades
+
+SharpAPI emite identificadores estables con clave entera (`numerical_id`) en cada entidad de referencia, además de objetos de referencia anidados autodescriptivos en cada fila de cuotas y en cada tramo de oportunidad. Esta página documenta qué garantizan esos IDs, cómo usarlos y cómo se relacionan con los IDs de cadena existentes.
+
+<Callout type="info">
+  **Novedad (mayo de 2026).** Tanto `numerical_id` como los objetos de referencia anidados son **aditivos**. Los IDs de cadena existentes (`sport: "baseball"`, `league: "mlb"`, `sportsbook: "pinnacle"`, `home_team: "New York Yankees"`) permanecen en todas las respuestas y no están obsoletos. No hay un plazo de eliminación — ambas formas se soportan indefinidamente.
+</Callout>
+
+## Novedades
+
+Cada endpoint de referencia (`/sports`, `/leagues`, `/sportsbooks`, `/markets`, `/teams`) ahora devuelve un entero `numerical_id` junto al `id` de slug existente. `/teams` devuelve además un campo `abbreviation` cuando se conoce.
+
+Cada fila de cuotas (y cada tramo de una oportunidad de EV / arbitraje / middle) ahora incluye seis **objetos de referencia anidados** opcionales que agrupan el `id`, la etiqueta de visualización y el `numerical_id` de la entidad directamente con la fila — sin necesidad de una segunda consulta a `/sports` o `/teams`:
+
+```json
+{
+  "home": {
+    "id": "new_york_yankees",
+    "numerical_id": 20,
+    "name": "New York Yankees",
+    "abbreviation": "NYY",
+    "logo": "https://cdn.opticodds.com/team-logos/baseball/36.png",
+    "city": "New York",
+    "mascot": "Yankees",
+    "conference": "AL",
+    "division": "East Division"
+  },
+  "away": {
+    "id": "boston_red_sox",
+    "numerical_id":  5,
+    "name": "Boston Red Sox",
+    "abbreviation": "BOS",
+    "logo": "https://cdn.opticodds.com/team-logos/baseball/14.png",
+    "city": "Boston",
+    "mascot": "Red Sox",
+    "conference": "AL",
+    "division": "East Division"
+  },
+  "sport_ref":      { "id": "baseball",         "numerical_id":  3, "name": "Baseball" },
+  "league_ref":     { "id": "mlb",              "numerical_id": 354, "label": "MLB" },
+  "market_ref":     { "id": "moneyline",        "numerical_id": 878, "label": "Moneyline" },
+  "sportsbook_ref": { "id": "pinnacle",         "numerical_id":  28, "label": "Pinnacle" }
+}
+```
+
+## Semántica de `numerical_id`
+
+Cada `numerical_id` se asigna desde un registro congelado por dominio en `api-adapters/sharp_atlas/`. El contrato es:
+
+| Propiedad | Garantía |
+|---|---|
+| **Congelado** | Una vez asignado, un `numerical_id` nunca se reutiliza, reasigna ni remapea a una entidad diferente. El `numerical_id: 20` de los Yankees será `20` hasta que la API se retire. |
+| **Denso desde 1** | Los IDs comienzan en `1` y se emiten secuencialmente por dominio. No existen IDs negativos o cero, ni saltos grandes. Deportes, ligas, casas de apuestas, mercados y equipos tienen cada uno un rango denso independiente. |
+| **Con ámbito de dominio** | Un `numerical_id` es único solo dentro de su dominio (deporte, liga, casa de apuestas, mercado, equipo). El `numerical_id: 3` de un deporte no tiene relación con el `numerical_id: 3` de un equipo. Combina el entero con el dominio para disambiguar. |
+| **Asignado, no derivado** | Los IDs se rastrean explícitamente en los JSONs del atlas — no son hashes del slug ni se calculan a partir del orden. Agregar una nueva entidad asigna el siguiente entero libre; renombrar un slug no cambia su `numerical_id`. |
+| **No es un ID de casa de apuestas** | Este es el identificador de SharpAPI, no el interno de la casa de apuestas. Los IDs nativos de evento/mercado/selección de cada casa siguen emitiéndose por fila — consulta `external_event_id`, `selection_id`, `market_id` y `external_ids` en el endpoint de [Eventos](/es/api-reference/events). |
+
+## Cuándo faltan campos
+
+Los objetos de referencia anidados se emiten **solo cuando la entidad subyacente ha sido mapeada en el atlas**. Para entidades no mapeadas — habitualmente ligas de larga cola, mercados exóticos o casas de apuestas recién añadidas antes de la asignación al catálogo — el bloque `*_ref` correspondiente se omite (o tiene `numerical_id: null`) y el campo de cadena existente en la fila es el único ID que verás.
+
+En la práctica:
+
+- Los deportes, ligas y casas principales están completamente mapeados — se puede esperar que todos los bloques `*_ref` estén presentes.
+- Los mercados de prop de jugador y los mercados de corners/tarjetas/períodos en fútbol tienen el catálogo más amplio; algunos tipos de prop nicho todavía están siendo asignados.
+- La `abbreviation` de equipo está poblada donde existe un código ampliamente conocido (ligas mayores de EE. UU., EPL, códigos cortos ATP/WTA). Para equipos menores o internacionales puede estar ausente.
+
+Los consumidores deben tratar cada bloque anidado como **opcional**. Los clientes genéricos deben recurrir al campo de cadena plano (`sport`, `league`, `sportsbook`, `home_team`, `away_team`, `market_type`) cuando el `*_ref` correspondiente no esté presente.
+
+## Uso recomendado
+
+### Indexación y joins
+Usa `numerical_id` como clave primaria al almacenar cuotas/oportunidades en tu propia base de datos. Las claves enteras son más pequeñas, más baratas de indexar y estables frente a renombrados de slug o ajustes en etiquetas de visualización.
+
+### Mapeo entre feeds
+Si ingieres de múltiples proveedores de datos, `numerical_id` te ofrece una comprobación de igualdad rápida dentro de las filas de SharpAPI. Para mapear **entre** proveedores, el `id` de slug sigue siendo la clave de join más portable — los slugs son legibles por humanos y tienden a coincidir entre proveedores más que los IDs enteros.
+
+### Visualización en la interfaz
+Usa `name` (deportes, equipos) o `label` (ligas, mercados, casas de apuestas) para mostrar; la `abbreviation` en `home`/`away` es adecuada para celdas compactas.
+
+### Streaming
+Los mismos objetos anidados aparecen en los frames SSE de `/api/v1/stream/odds` y en los payloads de cuotas de WebSocket v1 / v1.5 — no se requiere un stream separado.
+
+## Referencia de campos
+
+### Endpoints de referencia
+
+Cada endpoint de referencia añade `numerical_id` a su esquema de objeto existente. `/teams` añade además `abbreviation`.
+
+| Endpoint | Campo añadido | Tipo | Notas |
+|---|---|---|---|
+| [`/sports`](/es/api-reference/sports) | `numerical_id` | integer \| null | Dominio de ámbito de deporte |
+| [`/leagues`](/es/api-reference/leagues) | `numerical_id` | integer \| null | Dominio de ámbito de liga |
+| [`/sportsbooks`](/es/api-reference/sportsbooks) | `numerical_id` | integer \| null | Dominio de ámbito de casa de apuestas |
+| [`/markets`](/es/api-reference/markets) | `numerical_id` | integer \| null | Dominio de ámbito de tipo de mercado |
+| [`/teams`](/es/api-reference/teams) | `numerical_id`, `abbreviation`, `logo`, `city`, `mascot`, `conference`, `division` | integer \| null, string \| null | Dominio de ámbito de equipo. Los cinco últimos son metadatos del atlas obtenidos de OpticOdds. |
+
+### Bloques de referencia anidados en cuotas y tramos de oportunidad
+
+| Bloque | Dónde | Campos | Propósito |
+|---|---|---|---|
+| `home`, `away` | Cada fila de cuotas, cada tramo de oportunidad | `id`, `numerical_id`, `name`, `abbreviation`, `logo`, `city`, `mascot`, `conference`, `division` | Resolver los dos competidores sin una llamada separada a `/teams`. |
+| `sport_ref` | El mismo | `id`, `numerical_id`, `name` | Referencia de deporte lista para mostrar. |
+| `league_ref` | El mismo | `id`, `numerical_id`, `label` | Referencia de liga lista para mostrar. |
+| `market_ref` | El mismo | `id`, `numerical_id`, `label` | Referencia de mercado lista para mostrar (tipo de mercado canónico). |
+| `sportsbook_ref` | El mismo | `id`, `numerical_id`, `label` | Referencia de casa de apuestas lista para mostrar. |
+
+Todos los campos internos son **opcionales** dentro de un bloque. Un bloque puede estar presente con un `numerical_id` `null` si el slug ha sido mapeado pero la asignación del entero está pendiente; tanto `numerical_id` como el bloque completo pueden también estar ausentes para entidades no mapeadas.
+
+### Campos de metadatos de equipo
+
+Los bloques `home` / `away` exponen cinco campos de metadatos opcionales adicionales más allá de `id` / `numerical_id` / `name` / `abbreviation`. Se obtienen del atlas de SharpAPI y están poblados para la gran mayoría de equipos (≈93% en `logo`, con una cobertura comparable en el resto):
+
+| Campo | Ejemplo | Notas |
+|---|---|---|
+| `logo` | `"https://cdn.opticodds.com/team-logos/baseball/36.png"` | URL completa de CDN para el escudo del equipo. Trata el host como opaco; SharpAPI puede re-alojar el mismo recurso bajo su propio dominio en el futuro. |
+| `city` | `"New York"` | El anclaje geográfico del equipo. Para equipos de varias ciudades (p. ej. los New York Football Giants que juegan en NJ) seguimos la ciudad convencional de la liga. |
+| `mascot` | `"Yankees"` | La parte de mascota / apodo del nombre completo del equipo. |
+| `conference` | `"AL"`, `"AFC"`, `"Western"` | Conferencia / agrupación definida por la liga. El formato varía según la liga. |
+| `division` | `"East Division"`, `"NL East"`, `"Pacific Division"` | Subagrupación dentro de la conferencia, definida por la liga. |
+
+Los competidores de deportes individuales (tenistas, luchadores de MMA, golfistas, pilotos) generalmente no tienen ninguno de estos campos poblados — no son "equipos" en el sentido convencional y heredan solo `id` / `numerical_id` / `name`.
+
+## Migración
+
+No hay nada que migrar. Continúa usando los campos de cadena planos si cubren tus necesidades. Adopta los bloques `*_ref` y `numerical_id` de forma selectiva cuando:
+
+- necesites una clave entera estable para el almacenamiento,
+- quieras etiquetas listas para mostrar sin una segunda llamada a la API,
+- o estés construyendo una capa de normalización entre feeds.
+
+Los campos planos y los bloques anidados describen la misma fila — no se contradirán entre sí.
+
+## Relacionado
+
+- [Deportes](/es/api-reference/sports), [Ligas](/es/api-reference/leagues), [Casas de apuestas](/es/api-reference/sportsbooks), [Mercados](/es/api-reference/markets), [Equipos](/es/api-reference/teams) — endpoints de referencia con el nuevo campo `numerical_id`
+- [Snapshot de cuotas](/es/api-reference/odds), [Oportunidades +EV](/es/api-reference/opportunities-ev), [Arbitraje](/es/api-reference/opportunities-arbitrage), [Middles](/es/api-reference/opportunities-middles) — endpoints con bloques de referencia anidados
+- [Matching de eventos](/es/concepts/event-matching) — cómo SharpAPI une el mismo partido entre diferentes casas de apuestas

--- a/content/es/concepts/polymarket-resolution.mdx
+++ b/content/es/concepts/polymarket-resolution.mdx
@@ -1,0 +1,98 @@
+---
+title: "Estado de Resolución de Polymarket"
+description: "Cómo SharpAPI expone el ciclo de vida de resolución del oráculo optimista UMA en los mercados de Polymarket — liquidado, anulado, disputado, propuesto."
+---
+
+import { Callout } from 'nextra/components'
+
+# Estado de Resolución de Polymarket
+
+Polymarket es un CLOB de mercados de predicción cuyos mercados son calificados por el [oráculo optimista UMA](https://docs.uma.xyz/), no por una mesa de trading de una casa de apuestas. Cuando consultas las cuotas de Polymarket a través de SharpAPI, la fila puede incluir un campo adicional — `polymarket_resolution` — que refleja en qué punto del ciclo de vida de resolución UMA se encuentra ese mercado.
+
+Este campo es **exclusivo de Polymarket**. Las filas de otras casas de apuestas (Pinnacle, DraftKings, FanDuel, etc.) no lo incluyen, ya que sus formatos de datos de origen no emiten una señal equivalente. Consulta el [análisis del wire de Pinnacle](https://github.com/Mlaz-code/api-adapters/) para ver la investigación paralela que concluyó que el mismo campo no puede entregarse para los libros tradicionales.
+
+## Cuándo aparece el campo
+
+| Estado del mercado | `polymarket_resolution` |
+|---|---|
+| En operación activa | omitido (campo no presente) |
+| Cerrado, resuelto con ganador | `"settled_normal"` |
+| Cerrado, anulado / reembolsado | `"voided"` |
+| Cerrado, disputa UMA en curso | `"disputed"` |
+| Cerrado, propuesta UMA enviada, ventana de disputa abierta | `"proposed"` |
+| Cerrado, campos del ciclo de vida vacíos (mercado heredado) | `"unknown"` |
+| Cualquier libro que no sea Polymarket | omitido |
+
+El campo es **aditivo**. Los analizadores sintácticos existentes que ignoran campos desconocidos seguirán funcionando sin cambios.
+
+## Semántica de los valores
+
+### `settled_normal`
+
+El oráculo UMA declaró un resultado ganador. En un mercado binario, exactamente un resultado se resolvió a `$1.00` y el otro a `$0.00`. Este es el estado final habitual.
+
+```json
+{
+  "sportsbook": "polymarket",
+  "marketType": "binary",
+  "selection": "Yes",
+  "odds": -10000,
+  "polymarket_resolution": "settled_normal",
+  "trueProbability": 1.0
+}
+```
+
+### `voided`
+
+El oráculo UMA anuló el mercado — ambos resultados binarios se resolvieron a `$0.50` ("reembolso a todos"). Esta es la misma firma de wire para todos los casos siguientes:
+
+- Un partido cancelado (evento deportivo cancelado o abandonado)
+- Un participante que se retira antes del evento
+- El evento que nunca llega a ocurrir (por ejemplo, "ganador del Mapa 3" cuando la serie terminó en 2 mapas)
+- Cualquier otra anulación determinada por UMA
+
+<Callout type="warning">
+**Polymarket no distingue *por qué* se anuló un mercado.** El motivo en lenguaje natural se encuentra en el hilo de disputa UMA fuera de la cadena, en el frontend del oráculo UMA, no en la API de Polymarket. Si tu aplicación necesita saber si fue cancelación, retirada o no celebración del evento, esa información no puede obtenerse del wire de Polymarket — tendrías que leer directamente el cuerpo de la disputa UMA.
+
+Esta es una decisión de diseño intencional de la arquitectura del oráculo optimista de UMA, no una omisión de SharpAPI. Elegimos exponer `voided` como un único grupo en lugar de inferir a partir de heurísticas — según nuestra [política de no inferencia](https://github.com/Mlaz-code/api-adapters/), si el origen es ambiguo, no hacemos suposiciones.
+</Callout>
+
+### `disputed`
+
+El proponente UMA envió una resolución que fue impugnada. El mercado se encuentra ahora en una votación de los poseedores de tokens UMA, típicamente de 48 horas. La resolución final eventualmente pasará a `settled_normal` o `voided` una vez concluya la votación.
+
+### `proposed`
+
+El proponente UMA envió una resolución candidata; la ventana de disputa está abierta (típicamente 2 horas). El mercado pasará a `settled_normal` / `voided` una vez que la ventana se cierre sin impugnación, o a `disputed` si es impugnado.
+
+### `unknown`
+
+El mercado está cerrado pero los campos del ciclo de vida UMA están vacíos. Esto ocurre en mercados heredados de Polymarket anteriores al seguimiento del estado UMA, o en casos extremos poco frecuentes donde la API de Gamma no expone el historial del ciclo de vida. El campo es `unknown` en lugar de hacer suposiciones.
+
+## Resolución diferida
+
+Los mercados de Polymarket pueden resolverse días o semanas después de que termine el evento subyacente. El campo `polymarket_resolution` aparece siempre que el ciclo de vida de resolución avanza en el origen, incluso mucho después de que el mercado haya cerrado.
+
+Si tu aplicación procesa eventos de resolución (para calificación, conciliación de liquidaciones, etc.), monitoriza el stream SSE / WebSocket para detectar estas filas de llegada tardía.
+
+## Comparación con otros libros
+
+| Libro | ¿Campo equivalente? | Notas |
+|---|---|---|
+| **Polymarket** | `polymarket_resolution` | Enumeración de 5 estados, derivada del oráculo UMA |
+| **Kalshi** | _(aún no)_ | Kalshi tiene eventos de liquidación pero actualmente no los exponemos — solicitud separada |
+| **Pinnacle** | _(no disponible en origen)_ | El wire de Pinnacle no emite ningún campo de motivo en tiempo real; `cancellationReason` solo existe en el endpoint de socio de la Lines API posterior a la calificación |
+| **DraftKings / FanDuel / BetMGM / Caesars** | _(no disponible)_ | Los mercados suspendidos simplemente desaparecen del feed; no se emite ningún campo de estado |
+| **OpticOdds (comparación con el sector)** | _(sin motivo)_ | Existe `status: cancelled` a nivel de evento pero no incluye motivo; los objetos por mercado no tienen campo de estado |
+
+Los datos que los clientes desean — un motivo de liquidación por libro — no son un estándar del sector. Polymarket es el caso excepcional donde el wire de origen sí lo incluye, porque la resolución UMA está en cadena y es públicamente observable.
+
+## Por qué el campo lleva el prefijo de Polymarket
+
+Nombramos deliberadamente el campo `polymarket_resolution` en lugar de un genérico `resolutionStatus` para que quede claro que los valores son específicos de Polymarket. Una futura versión para Kalshi sería un campo `kalshiResolution` separado con su propio enumerado — los formatos de wire son suficientemente distintos como para que un enumerado unificado resultara o bien en el mínimo común denominador (inútil) o bien repleto de asteriscos para los valores "solo Polymarket" / "solo Kalshi".
+
+## Véase también
+
+- [Lista de casas de apuestas — mercados de predicción](/es/api-reference/sportsbooks#prediction-markets)
+- [Referencia de la API de cuotas](/es/api-reference/odds)
+- [En vivo vs. Previo al partido](/es/concepts/live-vs-prematch) — cubre la semántica relacionada de `marketStatus`

--- a/content/pt-BR/api-reference/conventions.mdx
+++ b/content/pt-BR/api-reference/conventions.mdx
@@ -9,7 +9,7 @@ import { Callout } from 'nextra/components'
 A SharpAPI retorna formatos de resposta previsíveis em todos os endpoints REST. Esta página codifica essas convenções para que você possa criar parsers genéricos, em vez de tratar cada endpoint como um caso especial.
 
 <Callout type="info">
-  Esta página descreve as convenções REST. Streams SSE são abordados em [SSE Stream](/pt-BR/api-reference/stream), e o protocolo WebSocket bidirecional possui sua própria [especificação AsyncAPI 3.0](/asyncapi.yaml).
+  Esta página descreve as convenções REST. Streams SSE são abordados em [SSE Stream](/pt-BR/api-reference/stream), e o protocolo WebSocket bidirecional possui sua própria [especificação AsyncAPI 3.0](https://docs.sharpapi.io/asyncapi.yaml).
 </Callout>
 
 ## Códigos de status HTTP, não envelopes
@@ -192,6 +192,6 @@ ETag: "9dc023776c4b382"
 ## Fonte da verdade legível por máquina
 
 - Superfície REST: [`openapi.json`](/openapi.json) (OpenAPI 3.1)
-- Superfície WebSocket: [`asyncapi.yaml`](/asyncapi.yaml) (AsyncAPI 3.0)
+- Superfície WebSocket: [`asyncapi.yaml`](https://docs.sharpapi.io/asyncapi.yaml) (AsyncAPI 3.0)
 
 Ambos os arquivos são publicados como assets estáticos e podem ser comparados (diff) em CI. Se esta página divergir da especificação, a especificação prevalece — a especificação é gerada a partir do servidor implantado.

--- a/content/pt-BR/concepts/_meta.js
+++ b/content/pt-BR/concepts/_meta.js
@@ -3,6 +3,8 @@ export default {
   "ev-calculation": "Cálculo de EV",
   arbitrage: "Arbitragem",
   "event-matching": "Correspondência de Eventos",
+  "entity-reference-ids": "IDs de Referência de Entidades",
   "live-vs-prematch": "Ao Vivo vs. Pré-Jogo",
   "pinnacle-odds-changed-at": "Pinnacle `odds_changed_at`",
+  "polymarket-resolution": "Resolução do Polymarket",
 }

--- a/content/pt-BR/concepts/entity-reference-ids.mdx
+++ b/content/pt-BR/concepts/entity-reference-ids.mdx
@@ -1,0 +1,144 @@
+---
+description: "IDs de referência de entidade — semântica de numerical_id, objetos de referência aninhados de time/esporte/liga/mercado/casa de apostas e como usá-los para joins, indexação e mapeamento entre feeds."
+---
+
+import { Callout } from 'nextra/components'
+
+# IDs de referência de entidade
+
+A SharpAPI emite identificadores inteiros estáveis (`numerical_id`) em cada entidade de referência, além de objetos de referência aninhados autodescritivos em cada linha de odds e leg de oportunidade. Esta página documenta o que esses IDs garantem, como usá-los e como eles se relacionam com os IDs de string existentes.
+
+<Callout type="info">
+  **Novo (maio de 2026).** Tanto o `numerical_id` quanto os objetos de referência aninhados são **aditivos**. Os IDs de string existentes (`sport: "baseball"`, `league: "mlb"`, `sportsbook: "pinnacle"`, `home_team: "New York Yankees"`) permanecem em todas as respostas e não estão obsoletos. Não há prazo de remoção — ambos os formatos são suportados indefinidamente.
+</Callout>
+
+## O que há de novo
+
+Cada endpoint de referência (`/sports`, `/leagues`, `/sportsbooks`, `/markets`, `/teams`) agora retorna um inteiro `numerical_id` ao lado do `id` slug existente. `/teams` retorna adicionalmente um campo `abbreviation` quando disponível.
+
+Cada linha de odds (e cada leg de uma oportunidade EV / arbitragem / middle) agora carrega seis **objetos de referência aninhados** opcionais que agrupam o `id`, o rótulo de exibição e o `numerical_id` da entidade diretamente com a linha — sem necessidade de segunda consulta a `/sports` ou `/teams`:
+
+```json
+{
+  "home": {
+    "id": "new_york_yankees",
+    "numerical_id": 20,
+    "name": "New York Yankees",
+    "abbreviation": "NYY",
+    "logo": "https://cdn.opticodds.com/team-logos/baseball/36.png",
+    "city": "New York",
+    "mascot": "Yankees",
+    "conference": "AL",
+    "division": "East Division"
+  },
+  "away": {
+    "id": "boston_red_sox",
+    "numerical_id":  5,
+    "name": "Boston Red Sox",
+    "abbreviation": "BOS",
+    "logo": "https://cdn.opticodds.com/team-logos/baseball/14.png",
+    "city": "Boston",
+    "mascot": "Red Sox",
+    "conference": "AL",
+    "division": "East Division"
+  },
+  "sport_ref":      { "id": "baseball",         "numerical_id":  3, "name": "Baseball" },
+  "league_ref":     { "id": "mlb",              "numerical_id": 354, "label": "MLB" },
+  "market_ref":     { "id": "moneyline",        "numerical_id": 878, "label": "Moneyline" },
+  "sportsbook_ref": { "id": "pinnacle",         "numerical_id":  28, "label": "Pinnacle" }
+}
+```
+
+## Semântica do `numerical_id`
+
+Cada `numerical_id` é alocado a partir de um registro congelado por domínio em `api-adapters/sharp_atlas/`. O contrato é:
+
+| Propriedade | Garantia |
+|---|---|
+| **Congelado** | Uma vez atribuído, um `numerical_id` nunca é reutilizado, reemitido ou remapeado para uma entidade diferente. O `numerical_id: 20` dos Yankees sempre será `20` até a aposentadoria da API. |
+| **Denso a partir de 1** | Os IDs começam em `1` e são emitidos sequencialmente por domínio. Não há IDs negativos, zeros ou grandes saltos. Esportes, ligas, casas de apostas, mercados e times têm cada um um intervalo denso independente. |
+| **Escopo por domínio** | Um `numerical_id` é único apenas dentro do seu domínio (esporte, liga, casa de apostas, mercado, time). `numerical_id: 3` em um esporte não tem relação com `numerical_id: 3` em um time. Combine o inteiro com o domínio para desambiguar. |
+| **Atribuído, não derivado** | Os IDs são rastreados explicitamente nos JSONs do atlas — não são hashes do slug nem calculados pela ordem de classificação. Adicionar uma nova entidade aloca o próximo inteiro livre; renomear um slug não altera seu `numerical_id`. |
+| **Não é um ID de casa de apostas** | Este é o identificador da SharpAPI, não o interno da casa de apostas. Os IDs nativos de evento/mercado/seleção de cada casa ainda são emitidos por linha — veja `external_event_id`, `selection_id`, `market_id` e `external_ids` no endpoint de [Eventos](/pt-BR/api-reference/events). |
+
+## Quando os campos estão ausentes
+
+Os objetos de referência aninhados são emitidos **somente quando a entidade subjacente foi mapeada no atlas**. Para entidades não mapeadas — tipicamente ligas de cauda longa, mercados exóticos ou casas de apostas recém-adicionadas antes da atribuição de catálogo — o bloco `*_ref` correspondente é omitido (ou tem `numerical_id: null`) e o campo de string existente na linha é o único ID disponível.
+
+Na prática:
+
+- Principais esportes, ligas e casas são totalmente mapeados — espere que todos os blocos `*_ref` estejam presentes.
+- Mercados de prop de jogadores e mercados de escanteios/cartões/períodos no futebol têm o catálogo mais amplo; alguns tipos de prop de nicho ainda estão sendo atribuídos.
+- O `abbreviation` de times é preenchido onde amplamente conhecido (ligas principais dos EUA, EPL, códigos curtos ATP/WTA). Para times menores ou internacionais, pode estar ausente.
+
+Os consumidores devem tratar cada bloco aninhado como **opcional**. Clientes genéricos devem recorrer ao campo de string plano (`sport`, `league`, `sportsbook`, `home_team`, `away_team`, `market_type`) quando o `*_ref` correspondente não estiver presente.
+
+## Uso recomendado
+
+### Indexação e joins
+Use `numerical_id` como chave primária ao armazenar odds/oportunidades em seu próprio banco de dados. Chaves inteiras são menores, mais baratas de indexar e estáveis em relação a renomeações de slug ou ajustes de rótulo de exibição.
+
+### Mapeamento entre feeds
+Se você ingere dados de múltiplos provedores, `numerical_id` fornece uma verificação de igualdade rápida dentro das linhas da SharpAPI. Para mapeamento **entre** fornecedores, o slug `id` ainda é a chave de join mais portátil — slugs são legíveis por humanos e tendem a se sobrepor entre fornecedores mais do que IDs inteiros.
+
+### Exibição na interface
+Use `name` (esportes, times) ou `label` (ligas, mercados, casas de apostas) para exibição; o `abbreviation` em `home`/`away` é adequado para células compactas.
+
+### Streaming
+Os mesmos objetos aninhados aparecem nos frames SSE de `/api/v1/stream/odds` e nos payloads de odds do WebSocket v1 / v1.5 — nenhum stream separado é necessário.
+
+## Referência de campos
+
+### Endpoints de referência
+
+Cada endpoint de referência adiciona `numerical_id` ao seu esquema de objeto existente. `/teams` adicionalmente inclui `abbreviation`.
+
+| Endpoint | Campo adicionado | Tipo | Notas |
+|---|---|---|---|
+| [`/sports`](/pt-BR/api-reference/sports) | `numerical_id` | integer \| null | Domínio de escopo de esporte |
+| [`/leagues`](/pt-BR/api-reference/leagues) | `numerical_id` | integer \| null | Domínio de escopo de liga |
+| [`/sportsbooks`](/pt-BR/api-reference/sportsbooks) | `numerical_id` | integer \| null | Domínio de escopo de casa de apostas |
+| [`/markets`](/pt-BR/api-reference/markets) | `numerical_id` | integer \| null | Domínio de escopo de tipo de mercado |
+| [`/teams`](/pt-BR/api-reference/teams) | `numerical_id`, `abbreviation`, `logo`, `city`, `mascot`, `conference`, `division` | integer \| null, string \| null | Domínio de escopo de time. Os últimos cinco são metadados do atlas provenientes da OpticOdds. |
+
+### Blocos de referência aninhados em odds e legs de oportunidade
+
+| Bloco | Onde | Campos | Finalidade |
+|---|---|---|---|
+| `home`, `away` | Cada linha de odds, cada leg de oportunidade | `id`, `numerical_id`, `name`, `abbreviation`, `logo`, `city`, `mascot`, `conference`, `division` | Resolva os dois competidores sem uma chamada separada a `/teams`. |
+| `sport_ref` | Mesmo | `id`, `numerical_id`, `name` | Referência de esporte pronta para exibição. |
+| `league_ref` | Mesmo | `id`, `numerical_id`, `label` | Referência de liga pronta para exibição. |
+| `market_ref` | Mesmo | `id`, `numerical_id`, `label` | Referência de mercado pronta para exibição (tipo de mercado canônico). |
+| `sportsbook_ref` | Mesmo | `id`, `numerical_id`, `label` | Referência de casa de apostas pronta para exibição. |
+
+Todos os campos internos são **opcionais** dentro de um bloco. Um bloco pode estar presente com `numerical_id` como `null` se o slug foi mapeado mas a atribuição do inteiro está pendente; tanto `numerical_id` quanto o bloco inteiro também podem estar ausentes para entidades não mapeadas.
+
+### Campos de metadados de times
+
+Os blocos `home` / `away` expõem cinco campos de metadados opcionais adicionais além de `id` / `numerical_id` / `name` / `abbreviation`. Eles são provenientes do atlas da SharpAPI e preenchidos para a grande maioria dos times (≈93% em `logo`, com cobertura comparável nos demais):
+
+| Campo | Exemplo | Notas |
+|---|---|---|
+| `logo` | `"https://cdn.opticodds.com/team-logos/baseball/36.png"` | URL completa da CDN para o escudo do time. Trate o host como opaco; a SharpAPI pode rehospedar o mesmo asset em seu próprio domínio no futuro. |
+| `city` | `"New York"` | A referência geográfica do time. Para times de múltiplas cidades (ex.: New York Football Giants que joga no NJ) seguimos a cidade convencional da liga. |
+| `mascot` | `"Yankees"` | A parte do mascote / apelido do nome completo do time. |
+| `conference` | `"AL"`, `"AFC"`, `"Western"` | Conferência / agrupamento definido pela liga. O formato varia por liga. |
+| `division` | `"East Division"`, `"NL East"`, `"Pacific Division"` | Sub-agrupamento dentro da conferência, definido pela liga. |
+
+Competidores de esportes individuais (tenistas, lutadores de MMA, golfistas, pilotos) geralmente não têm nenhum desses campos preenchidos — eles não são "times" no sentido convencional e herdam apenas `id` / `numerical_id` / `name`.
+
+## Migração
+
+Não há nada a migrar. Continue usando os campos de string planos se eles atenderem às suas necessidades. Adote os blocos `*_ref` e o `numerical_id` seletivamente quando:
+
+- você precisar de uma chave inteira estável para armazenamento,
+- quiser rótulos prontos para exibição sem uma segunda chamada de API,
+- ou estiver construindo uma camada de normalização entre feeds.
+
+Os campos planos e os blocos aninhados descrevem a mesma linha — eles não se contradirão.
+
+## Relacionados
+
+- [Sports](/pt-BR/api-reference/sports), [Leagues](/pt-BR/api-reference/leagues), [Sportsbooks](/pt-BR/api-reference/sportsbooks), [Markets](/pt-BR/api-reference/markets), [Teams](/pt-BR/api-reference/teams) — endpoints de referência com o novo campo `numerical_id`
+- [Odds Snapshot](/pt-BR/api-reference/odds), [Oportunidades +EV](/pt-BR/api-reference/opportunities-ev), [Arbitragem](/pt-BR/api-reference/opportunities-arbitrage), [Middles](/pt-BR/api-reference/opportunities-middles) — endpoints com blocos de referência aninhados
+- [Correspondência de Eventos](/pt-BR/concepts/event-matching) — como a SharpAPI une o mesmo evento entre casas de apostas

--- a/content/pt-BR/concepts/polymarket-resolution.mdx
+++ b/content/pt-BR/concepts/polymarket-resolution.mdx
@@ -1,0 +1,98 @@
+---
+title: "Status de Resolução do Polymarket"
+description: "Como a SharpAPI expõe o ciclo de vida de resolução do oráculo otimista UMA nos mercados Polymarket — liquidado, anulado, disputado, proposto."
+---
+
+import { Callout } from 'nextra/components'
+
+# Status de Resolução do Polymarket
+
+Polymarket é um CLOB de mercado de previsões cujos mercados são avaliados pelo [oráculo otimista UMA](https://docs.uma.xyz/), não por uma mesa de trading de casa de apostas. Quando você consulta as odds do Polymarket através da SharpAPI, a linha pode conter um campo extra — `polymarket_resolution` — que reflete onde esse mercado está no ciclo de vida de resolução do UMA.
+
+Este campo é **exclusivo do Polymarket**. Linhas de outras casas de apostas (Pinnacle, DraftKings, FanDuel, etc.) não o incluem porque seus formatos de dados upstream não emitem um sinal equivalente. Veja a [análise do wire do Pinnacle](https://github.com/Mlaz-code/api-adapters/) para a investigação paralela que concluiu que o mesmo campo não pode ser entregue para casas tradicionais.
+
+## Quando o campo aparece
+
+| Estado do mercado | `polymarket_resolution` |
+|---|---|
+| Negociando ativamente | omitido (campo não presente) |
+| Fechado, resolvido com um vencedor | `"settled_normal"` |
+| Fechado, anulado / reembolsado | `"voided"` |
+| Fechado, disputa UMA em andamento | `"disputed"` |
+| Fechado, proposta UMA enviada, janela de disputa aberta | `"proposed"` |
+| Fechado, campos do ciclo de vida vazios (mercado legado) | `"unknown"` |
+| Qualquer casa que não seja Polymarket | omitido |
+
+O campo é **aditivo**. Parsers existentes que ignoram campos desconhecidos continuarão funcionando sem alterações.
+
+## Semântica dos valores
+
+### `settled_normal`
+
+O oráculo UMA declarou um resultado vencedor. Em um mercado binário, exatamente um resultado foi resolvido para `$1.00` e o outro para `$0.00`. Este é o estado final típico.
+
+```json
+{
+  "sportsbook": "polymarket",
+  "marketType": "binary",
+  "selection": "Yes",
+  "odds": -10000,
+  "polymarket_resolution": "settled_normal",
+  "trueProbability": 1.0
+}
+```
+
+### `voided`
+
+O oráculo UMA anulou o mercado — ambos os resultados binários foram resolvidos para `$0.50` ("reembolso a todos"). Esta é a mesma assinatura de wire para todos os casos:
+
+- Uma partida cancelada (evento esportivo cancelado ou abandonado)
+- Um participante se retirando antes do evento
+- O evento nunca ocorrendo (por exemplo, "vencedor do Mapa 3" quando a série terminou em 2 mapas)
+- Qualquer outra anulação determinada pelo UMA
+
+<Callout type="warning">
+**O Polymarket não distingue *por que* um mercado foi anulado.** O motivo legível está no thread de disputa UMA off-chain no frontend do oráculo UMA, não na API do Polymarket. Se sua aplicação precisa saber se foi cancelamento, retirada ou não ocorrência do evento, essa informação não pode ser obtida do wire do Polymarket — você precisaria ler o corpo da disputa UMA diretamente.
+
+Esta é uma decisão de design intencional da arquitetura do oráculo otimista do UMA, não uma omissão da SharpAPI. Escolhemos expor `voided` como um único bucket em vez de inferir a partir de heurísticas — conforme nossa [política de não inferência](https://github.com/Mlaz-code/api-adapters/), se o upstream é ambíguo, não fazemos suposições.
+</Callout>
+
+### `disputed`
+
+O proponente UMA enviou uma resolução que foi contestada. O mercado está agora em uma votação de detentores de tokens UMA, tipicamente de 48 horas. A resolução terminal eventualmente se tornará `settled_normal` ou `voided` após a conclusão da votação.
+
+### `proposed`
+
+O proponente UMA enviou uma resolução candidata; a janela de disputa está aberta (tipicamente 2 horas). O mercado fará a transição para `settled_normal` / `voided` assim que a janela fechar sem contestação, ou para `disputed` se contestado.
+
+### `unknown`
+
+O mercado está fechado mas os campos do ciclo de vida UMA estão vazios. Isso acontece em mercados legados do Polymarket anteriores ao rastreamento de status UMA, ou em casos extremos raros onde a API Gamma não retorna o histórico do ciclo de vida. O campo é `unknown` em vez de fazer suposições.
+
+## Resolução atrasada
+
+Os mercados do Polymarket podem ser resolvidos dias ou semanas após o término do evento subjacente. O campo `polymarket_resolution` aparece sempre que o ciclo de vida de resolução upstream avança, mesmo muito tempo após o fechamento do mercado.
+
+Se sua aplicação processa eventos de resolução (para avaliação, reconciliação de liquidação, etc.), monitore o stream SSE / WebSocket para essas linhas de chegada tardia.
+
+## Comparação com outras casas
+
+| Casa | Campo equivalente? | Notas |
+|---|---|---|
+| **Polymarket** | `polymarket_resolution` | Enum de 5 estados, derivado do oráculo UMA |
+| **Kalshi** | _(ainda não)_ | Kalshi tem eventos de liquidação mas não os expomos hoje — solicitação separada |
+| **Pinnacle** | _(não disponível upstream)_ | O wire do Pinnacle não emite campo de motivo em tempo real; `cancellationReason` existe apenas no endpoint parceiro da Lines API pós-avaliação |
+| **DraftKings / FanDuel / BetMGM / Caesars** | _(não disponível)_ | Mercados suspensos simplesmente desaparecem do feed; nenhum campo de status é emitido |
+| **OpticOdds (comparação do setor)** | _(sem motivo)_ | `status: cancelled` a nível de fixture existe mas não traz motivo; objetos por mercado não têm campo de status |
+
+Os dados que os clientes desejam — um motivo de liquidação por casa — não são padrão do setor. Polymarket é o caso raro onde o wire upstream realmente o contém, porque a resolução UMA é on-chain e publicamente observável.
+
+## Por que o campo tem prefixo Polymarket
+
+Nomeamos deliberadamente o campo `polymarket_resolution` em vez de um genérico `resolutionStatus` para que fique óbvio que os valores são específicos do Polymarket. Uma futura versão para Kalshi seria um campo `kalshiResolution` separado com seu próprio enum — os formatos de wire são diferentes o suficiente para que um enum unificado seria ou o menor denominador comum (inútil) ou cheio de asteriscos para valores "apenas Polymarket" / "apenas Kalshi".
+
+## Veja também
+
+- [Lista de casas de apostas — mercados de previsão](/pt-BR/api-reference/sportsbooks#prediction-markets)
+- [Referência da API de odds](/pt-BR/api-reference/odds)
+- [Ao Vivo vs. Pré-Jogo](/pt-BR/concepts/live-vs-prematch) — cobre a semântica relacionada de `marketStatus`


### PR DESCRIPTION
## Summary
- Add de/es/pt-BR translations for `concepts/entity-reference-ids` and `concepts/polymarket-resolution` (6 new pages)
- Update `_meta.js` for de/es/pt-BR concepts with new navigation entries
- Fix `asyncapi.yaml` links in all 4 locale conventions pages to use absolute URL (`https://docs.sharpapi.io/asyncapi.yaml`) — prevents Nextra from locale-prefixing the path and generating 404s

## Impact
Resolves **all 35 new errors** from the May 21 Semrush site audit:
- 10x pages returning 4XX status code
- 10x broken internal links
- 9x hreflang conflicts within page source code
- 6x issues with incorrect hreflang links

Expected score recovery: Site Health 94% → ~98%, International SEO 84% → ~93%

## Test plan
- [ ] Verify `docs.sharpapi.io/de/concepts/entity-reference-ids` returns 200
- [ ] Verify `docs.sharpapi.io/es/concepts/polymarket-resolution` returns 200
- [ ] Verify `docs.sharpapi.io/pt-BR/concepts/entity-reference-ids` returns 200
- [ ] Verify asyncapi.yaml link in conventions page resolves correctly
- [ ] Re-run Semrush site audit after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)