### PR TITLE
fix(seo): trailing slash on homepage hreflang/canonical

### DIFF
--- a/app/[lang]/[[...mdxPath]]/page.tsx
+++ b/app/[lang]/[[...mdxPath]]/page.tsx
@@ -10,8 +10,8 @@ const DEFAULT_LOCALE = 'en'
 export async function generateMetadata(props) {
   const params = await props.params
   const { metadata } = await importPage(params.mdxPath, params.lang)
-  const path = params.mdxPath ? `/${params.lang}/${params.mdxPath.join('/')}` : `/${params.lang}`
-  const subPath = params.mdxPath ? `/${params.mdxPath.join('/')}` : ''
+  const path = params.mdxPath ? `/${params.lang}/${params.mdxPath.join('/')}` : `/${params.lang}/`
+  const subPath = params.mdxPath ? `/${params.mdxPath.join('/')}` : '/'
   const languages: Record<string, string> = {}
   for (const l of LOCALES) {
     languages[l] = `https://docs.sharpapi.io/${l}${subPath}`


### PR DESCRIPTION
## Summary
- Adds trailing slash to canonical and hreflang URLs for locale homepages (/en/, /de/, /es/, /pt-BR/)
- Fixes 9 Semrush errors: "Conflicting hreflang and rel=canonical" + "No self-referencing hreflang"
- Deep page URLs unchanged — only homepage (empty mdxPath) affected

## Root cause
`generateMetadata` produced `/en` (no trailing slash) for canonical/hreflang, but Vercel serves the page at `/en/` (with trailing slash). Semrush sees the mismatch as conflicting signals.

## Test plan
- [ ] Verify build succeeds
- [ ] curl homepage and confirm canonical has trailing slash
- [ ] Re-run Semrush crawl to confirm 0 hreflang errors