### PR TITLE
fix(seo): trailing slash consistency for hreflang/canonical/sitemap

### DIFF
--- a/app/[lang]/[[...mdxPath]]/page.tsx
+++ b/app/[lang]/[[...mdxPath]]/page.tsx
@@ -10,8 +10,8 @@ const DEFAULT_LOCALE = 'en'
 export async function generateMetadata(props) {
   const params = await props.params
   const { metadata } = await importPage(params.mdxPath, params.lang)
-  const path = params.mdxPath ? `/${params.lang}/${params.mdxPath.join('/')}` : `/${params.lang}/`
-  const subPath = params.mdxPath ? `/${params.mdxPath.join('/')}` : '/'
+  const path = params.mdxPath ? `/${params.lang}/${params.mdxPath.join('/')}/` : `/${params.lang}/`
+  const subPath = params.mdxPath ? `/${params.mdxPath.join('/')}/` : '/'
   const languages: Record<string, string> = {}
   for (const l of LOCALES) {
     languages[l] = `https://docs.sharpapi.io/${l}${subPath}`

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,7 @@ const withNextra = nextra({
 
 export default withNextra({
   output: 'export',
+  trailingSlash: true,
   images: { unoptimized: true },
   // Nextra reads i18n config, extracts locales, then removes it (App Router compatible)
   i18n: {

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -64,7 +64,7 @@ async function lastmod(file) {
 }
 
 function url(locale, route) {
-  const path = route ? `/${locale}/${route}` : `/${locale}`
+  const path = route ? `/${locale}/${route}/` : `/${locale}/`
   return `${HOST}${path}`
 }
 


### PR DESCRIPTION
## Summary
- Enables `trailingSlash: true` in Next.js config — Vercel will 308-redirect `/en` → `/en/`
- Updates `page.tsx` to produce trailing-slash canonical and hreflang URLs for all pages
- Updates sitemap generator to emit trailing-slash `<loc>` and `<xhtml:link>` URLs

## Root cause
Vercel serves both `/en` and `/en/` as HTTP 200 with identical content (no redirect). Semrush discovers URLs from the sitemap (no trailing slash) and from internal links (with trailing slash), treats them as distinct, and flags the mismatch between the crawled URL and canonical/hreflang tags.

## What changes
- `next.config.mjs`: added `trailingSlash: true`
- `page.tsx`: all canonical/hreflang/OG URLs now end with `/`
- `generate-sitemap.mjs`: all `<loc>` and hreflang `href` URLs now end with `/`
- Static export generates `en/index.html` instead of `en.html` (directory-based)

## Test plan
- [x] Local build succeeds
- [ ] Verify Vercel 308 redirects `/en` → `/en/` after deploy
- [ ] Re-run Semrush crawl to confirm 0 hreflang errors