### PR TITLE
fix(ci): check-links entry path for trailingSlash

### DIFF
--- a/app/[lang]/[[...mdxPath]]/page.tsx
+++ b/app/[lang]/[[...mdxPath]]/page.tsx
@@ -10,8 +10,8 @@ const DEFAULT_LOCALE = 'en'
 export async function generateMetadata(props) {
   const params = await props.params
   const { metadata } = await importPage(params.mdxPath, params.lang)
-  const path = params.mdxPath ? `/${params.lang}/${params.mdxPath.join('/')}` : `/${params.lang}/`
-  const subPath = params.mdxPath ? `/${params.mdxPath.join('/')}` : '/'
+  const path = params.mdxPath ? `/${params.lang}/${params.mdxPath.join('/')}/` : `/${params.lang}/`
+  const subPath = params.mdxPath ? `/${params.mdxPath.join('/')}/` : '/'
   const languages: Record<string, string> = {}
   for (const l of LOCALES) {
     languages[l] = `https://docs.sharpapi.io/${l}${subPath}`

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,7 @@ const withNextra = nextra({
 
 export default withNextra({
   output: 'export',
+  trailingSlash: true,
   images: { unoptimized: true },
   // Nextra reads i18n config, extracts locales, then removes it (App Router compatible)
   i18n: {

--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 
 PORT=${PORT:-8765}
 OUT_DIR=${OUT_DIR:-out}
-ENTRY_PATH=${ENTRY_PATH:-/en.html}
+ENTRY_PATH=${ENTRY_PATH:-/en/}
 
 if [ ! -d "$OUT_DIR" ]; then
     echo "ERROR: $OUT_DIR not found — run \`pnpm build\` first" >&2

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -64,7 +64,7 @@ async function lastmod(file) {
 }
 
 function url(locale, route) {
-  const path = route ? `/${locale}/${route}` : `/${locale}`
+  const path = route ? `/${locale}/${route}/` : `/${locale}/`
   return `${HOST}${path}`
 }
 


### PR DESCRIPTION
## Summary
Follow-up to #236. The check-links CI step hardcodes `/en.html` as entry path, but with `trailingSlash: true` the file is now `en/index.html` (served as `/en/`).

Updates entry path from `/en.html` to `/en/`.