### PR TITLE
fix(links): absolute URL for openapi.json in conventions

### DIFF
--- a/app/[lang]/[[...mdxPath]]/page.tsx
+++ b/app/[lang]/[[...mdxPath]]/page.tsx
@@ -10,8 +10,8 @@ const DEFAULT_LOCALE = 'en'
 export async function generateMetadata(props) {
   const params = await props.params
   const { metadata } = await importPage(params.mdxPath, params.lang)
-  const path = params.mdxPath ? `/${params.lang}/${params.mdxPath.join('/')}` : `/${params.lang}/`
-  const subPath = params.mdxPath ? `/${params.mdxPath.join('/')}` : '/'
+  const path = params.mdxPath ? `/${params.lang}/${params.mdxPath.join('/')}/` : `/${params.lang}/`
+  const subPath = params.mdxPath ? `/${params.mdxPath.join('/')}/` : '/'
   const languages: Record<string, string> = {}
   for (const l of LOCALES) {
     languages[l] = `https://docs.sharpapi.io/${l}${subPath}`

--- a/content/de/api-reference/conventions.mdx
+++ b/content/de/api-reference/conventions.mdx
@@ -191,7 +191,7 @@ ETag: "9dc023776c4b382"
 
 ## Maschinenlesbare Quelle der Wahrheit
 
-- REST-Oberfläche: [`openapi.json`](/openapi.json) (OpenAPI 3.1)
+- REST-Oberfläche: [`openapi.json`](https://docs.sharpapi.io/openapi.json) (OpenAPI 3.1)
 - WebSocket-Oberfläche: [`asyncapi.yaml`](https://docs.sharpapi.io/asyncapi.yaml) (AsyncAPI 3.0)
 
 Beide Dateien werden als statische Assets veröffentlicht und können in CI verglichen werden. Wenn diese Seite von der Spezifikation abweicht, gewinnt die Spezifikation — die Spezifikation wird vom bereitgestellten Server generiert.

--- a/content/en/api-reference/conventions.mdx
+++ b/content/en/api-reference/conventions.mdx
@@ -191,7 +191,7 @@ ETag: "9dc023776c4b382"
 
 ## Machine-readable source of truth
 
-- REST surface: [`openapi.json`](/openapi.json) (OpenAPI 3.1)
+- REST surface: [`openapi.json`](https://docs.sharpapi.io/openapi.json) (OpenAPI 3.1)
 - WebSocket surface: [`asyncapi.yaml`](https://docs.sharpapi.io/asyncapi.yaml) (AsyncAPI 3.0)
 
 Both files are published as static assets and can be diffed in CI. If this page drifts from the spec, the spec wins — the spec is generated from the deployed server.

--- a/content/es/api-reference/conventions.mdx
+++ b/content/es/api-reference/conventions.mdx
@@ -191,7 +191,7 @@ ETag: "9dc023776c4b382"
 
 ## Fuente de verdad legible por máquina
 
-- Superficie REST: [`openapi.json`](/openapi.json) (OpenAPI 3.1)
+- Superficie REST: [`openapi.json`](https://docs.sharpapi.io/openapi.json) (OpenAPI 3.1)
 - Superficie WebSocket: [`asyncapi.yaml`](https://docs.sharpapi.io/asyncapi.yaml) (AsyncAPI 3.0)
 
 Ambos archivos se publican como recursos estáticos y se pueden comparar en CI. Si esta página se desvía de la especificación, la especificación gana: la especificación se genera a partir del servidor desplegado.

--- a/content/pt-BR/api-reference/conventions.mdx
+++ b/content/pt-BR/api-reference/conventions.mdx
@@ -191,7 +191,7 @@ ETag: "9dc023776c4b382"
 
 ## Fonte da verdade legível por máquina
 
-- Superfície REST: [`openapi.json`](/openapi.json) (OpenAPI 3.1)
+- Superfície REST: [`openapi.json`](https://docs.sharpapi.io/openapi.json) (OpenAPI 3.1)
 - Superfície WebSocket: [`asyncapi.yaml`](https://docs.sharpapi.io/asyncapi.yaml) (AsyncAPI 3.0)
 
 Ambos os arquivos são publicados como assets estáticos e podem ser comparados (diff) em CI. Se esta página divergir da especificação, a especificação prevalece — a especificação é gerada a partir do servidor implantado.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,7 @@ const withNextra = nextra({
 
 export default withNextra({
   output: 'export',
+  trailingSlash: true,
   images: { unoptimized: true },
   // Nextra reads i18n config, extracts locales, then removes it (App Router compatible)
   i18n: {

--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 
 PORT=${PORT:-8765}
 OUT_DIR=${OUT_DIR:-out}
-ENTRY_PATH=${ENTRY_PATH:-/en.html}
+ENTRY_PATH=${ENTRY_PATH:-/en/}
 
 if [ ! -d "$OUT_DIR" ]; then
     echo "ERROR: $OUT_DIR not found — run \`pnpm build\` first" >&2

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -64,7 +64,7 @@ async function lastmod(file) {
 }
 
 function url(locale, route) {
-  const path = route ? `/${locale}/${route}` : `/${locale}`
+  const path = route ? `/${locale}/${route}/` : `/${locale}/`
   return `${HOST}${path}`
 }
 


### PR DESCRIPTION
Same fix as asyncapi.yaml in #234 — relative `/openapi.json` link gets locale-prefixed to `/en/openapi.json` (404). Use absolute URL.