### PR TITLE
fix(seo): vercel.json trailingSlash for edge redirects

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,7 @@
   "redirects": [
     {
       "source": "/",
-      "destination": "/en",
+      "destination": "/en/",
       "permanent": true
     },
     {
@@ -189,5 +189,6 @@
       "source": "/ingest/:path*",
       "destination": "https://us.i.posthog.com/:path*"
     }
-  ]
+  ],
+  "trailingSlash": true
 }


### PR DESCRIPTION
## Summary
Adds `trailingSlash: true` to vercel.json so Vercel enforces 308 redirects at the edge (`/en` → `/en/`). Without this, both URL forms return 200 and Semrush flags hreflang conflicts on both variants.

Also updates the root redirect `/` → `/en/` to avoid a double redirect chain.

## Context
PR #236 added `trailingSlash: true` to next.config.mjs (build output) but Vercel static hosting needs the setting in vercel.json to enforce edge redirects.