### PR TITLE
docs(odds): document is_main_line on /odds + /odds/best

### DIFF
--- a/content/en/api-reference/odds-best.mdx
+++ b/content/en/api-reference/odds-best.mdx
@@ -29,6 +29,7 @@ Best Odds is available on all tiers, including Free. The sportsbooks compared de
 | `market` | string | all | Filter by market type(s), comma-separated (e.g., `moneyline`, `spread`, `total`). Supports category aliases — see [Odds: Market Category Aliases](/en/api-reference/odds/#market-category-aliases). |
 | `event` | string | — | Filter by event ID(s), comma-separated |
 | `live` | boolean | — | `true` = live only, `false` = prematch only, omit = both |
+| `is_main_line` | boolean | — | `true` = main-line entries only (consensus line for each `(event, market, selection)` cohort plus no-line markets like moneyline); `false` = alt-line entries only; omit = both. See the `is_main_line` response field below for the cohort semantics. |
 | `min_odds` | number | — | Minimum American odds filter |
 | `max_odds` | number | — | Maximum American odds filter |
 | `limit` | integer | 50 | Max results per page (max 200) |
@@ -201,6 +202,7 @@ X-Request-Id: req_best_789xyz
 | `market_type` | string | Market type (e.g., `moneyline`, `spread`, `total`) |
 | `selection` | string | Selection name (team name, Over/Under) |
 | `line` | number \| null | Line value (for spreads/totals) |
+| `is_main_line` | boolean | `true` for the consensus main line of this `(event, market_type, selection)` cohort and for no-line markets (moneyline, outright); `false` for alt-line entries and rows whose cohort hasn't been published yet (cold start). Filterable via `?is_main_line=true`. Mirrors the [`is_main_line` field on `/odds`](/en/api-reference/odds/#response-fields). |
 | `best_odds` | object | Best odds available across all books |
 | `best_odds.american` | number | Best American odds |
 | `best_odds.decimal` | number | Best decimal odds |

--- a/content/en/api-reference/odds.mdx
+++ b/content/en/api-reference/odds.mdx
@@ -196,6 +196,8 @@ The example below shows the flat fields only. As of May 2026, every row also car
       "odds_decimal": 1.667,
       "odds_probability": 0.60,
       "line": null,
+      "is_main_line": true,
+      "is_alternate_line": false,
       "event_start_time": "2026-01-26T19:00:00Z",
       "last_seen_at": "2026-01-26T02:10:24.125Z",
       "wire_received_at": "2026-01-26T02:10:24.087Z",
@@ -217,6 +219,8 @@ The example below shows the flat fields only. As of May 2026, every row also car
       "odds_decimal": 2.30,
       "odds_probability": 0.4348,
       "line": null,
+      "is_main_line": true,
+      "is_alternate_line": false,
       "event_start_time": "2026-01-26T19:00:00Z",
       "last_seen_at": "2026-01-26T02:10:24.125Z",
       "wire_received_at": "2026-01-26T02:10:24.087Z",
@@ -318,7 +322,8 @@ X-Request-Id: req_abc123def456
 | `odds_decimal` | number | Decimal odds (e.g., 1.909) |
 | `odds_probability` | number | Implied probability (e.g., 0.5238) |
 | `line` | number \| null | Spread or total line value (`null` for moneyline) |
-| `is_alternate_line` | boolean\|undefined | `true` when this row's `line` differs from the canonical main line for its `(event, market_type, player)` group. Always `false` for markets with no line (moneyline, outright). Stable on [`/opportunities/ev`](/en/api-reference/opportunities-ev/) today; rolling out to `/odds` rows. Use to separate main-line and alt-line snapshots. |
+| `is_alternate_line` | boolean | `true` when this row's `line` differs from the canonical main line for its `(event, market_type, selection)` group. `false` for the consensus main line, for no-line markets (moneyline, outright), and for rows whose cohort hasn't been published yet (cold start, brand-new event). See `is_main_line` for the positive-polarity sibling that disambiguates "main" from "cohort-pending". |
+| `is_main_line` | boolean | `true` when this row's `line` equals the canonical main line for its `(event, market_type, selection)` group, AND for no-line markets (moneyline, outright — always main by definition). `false` for alt-line rows and for rows whose cohort hasn't been published yet. **Mutually exclusive with `is_alternate_line`:** both true never coexists; both false is the cohort-pending state. Filter for `is_main_line=true` when you want a positive "main lines only" view that excludes cohort-pending rows. Also accepted as a query filter on [`/odds/best?is_main_line=true`](/en/api-reference/odds-best/). |
 | `event_start_time` | string | ISO 8601 event start time |
 | `last_seen_at` | string | ISO 8601 timestamp of our adapter's last observation of this row. Advances every ingest cycle even when the content is unchanged — use as a heartbeat that the row is still being maintained, not as an ingest-latency benchmark. |
 | `wire_received_at` | string\|undefined | ISO 8601 timestamp of when SharpAPI first observed a content change for this row, carried forward across subsequent unchanged refreshes. **Use this field for ingest-latency benchmarking** — it isolates SharpAPI's pipeline contribution from the sportsbook's source-side publish cadence. Omitted on cold-start rows where no prior observation exists. See [Understanding Pinnacle's `odds_changed_at`](/en/concepts/pinnacle-odds-changed-at/#benchmarking-pipeline-latency). |


### PR DESCRIPTION
Refs SHA-3692
Refs SHA-3521
Type: docs

## Summary

Documents the new `is_main_line` field shipped in [sharp-api-go #678](https://github.com/Mlaz-code/sharp-api-go/pull/678) and the pre-existing-but-undocumented `?is_main_line=true` filter on `/odds/best`.

- **`content/en/api-reference/odds.mdx`** — rewrites the `is_alternate_line` entry to call out the three-way ambiguity (main / no-line / cohort-pending), adds a new `is_main_line` entry next to it with mutual-exclusion semantics, and stamps both flags into the JSON sample rows.
- **`content/en/api-reference/odds-best.mdx`** — documents the `?is_main_line=true` query filter (already lives in code at `sharp-api-go/main.go:7124` but was never in the docs) and adds the response-field entry.

## Why

TU Dang (SHA-3692) and rogervtay (SHA-3521 line) both needed positive-polarity main-line detection. `is_alternate_line: false` overloads three distinct states on the wire — adding `is_main_line` lets clients filter cleanly. Field is live in production (verified Pinnacle MLB sample shows all 4 cohort states with the mutual-exclusion invariant intact).

## Scope

EN locale only. The DE/ES/PT-BR translations are stale from the original i18n PR (#9d35b71) and haven't been kept in sync with recent EN updates — separate catch-up.

## Test plan

- [x] Table column counts validated against existing baseline rows
- [x] Sample JSON syntactically valid (matched against shape of unchanged adjacent rows)
- [ ] Vercel preview deploy renders the field reference + JSON samples correctly
- [ ] Production deploy after merge — verify the field appears on https://docs.sharpapi.io/en/api-reference/odds/#response-fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)