### PR TITLE
docs(gamestate): document baseball in_play block (SHA-3716)

### DIFF
--- a/content/en/api-reference/gamestate.mdx
+++ b/content/en/api-reference/gamestate.mdx
@@ -102,10 +102,51 @@ tennis events carry `sets_home` / `server`; hockey events carry
 | `power_play` | hockey | `"home" \| "away"` |
 | `sets_home`, `sets_away` | tennis | integer (sets won) |
 | `hits_home`, `hits_away` | baseball | integer |
-| `home_pitcher`, `away_pitcher` | baseball | string — starting pitcher display name |
+| `errors_home`, `errors_away` | baseball | integer — fielding errors |
+| `home_pitcher`, `away_pitcher` | baseball | string — **starting** pitcher display name (roster-level, not the pitcher currently on the mound — see `in_play.currentPitcher` below) |
+| `in_play` | baseball | object — at-bat state; see [Baseball `in_play` block](#baseball-in_play-block) |
 | `wickets_home`, `wickets_away` | cricket | integer |
 | `overs` | cricket | float |
 | `batting_team` | cricket | `"home" \| "away"` |
+
+### Baseball `in_play` block
+
+Per-at-bat state on live baseball events. Populated whenever the
+contributing book exposes pitch-level data (currently FanDuel, BetMGM,
+Betway, theScoreBet, and ProphetX); omitted otherwise. Inner field
+names are **camelCase** — they are not snake-cased by the API
+transform.
+
+```jsonc
+"in_play": {
+  "outs": 1,                                                 // 0, 1, or 2
+  "balls": 2,                                                // 0-3
+  "strikes": 1,                                              // 0-2
+  "runners": {"first": true, "second": false, "third": true},
+  "currentPitcher": "Zach Agnos",                            // pitcher on the mound now
+  "currentBatter": "Tyrone Taylor"                           // active hitter
+}
+```
+
+| Field | Type | Range / Notes |
+|---|---|---|
+| `outs` | integer | `0`, `1`, or `2`. **`3` is never emitted** — by the time the third out is recorded upstream, the next half-inning has already begun (`outs` returns to `0` and `game_period` advances). The third out manifests as a transition between frames, not a steady-state value. |
+| `balls` | integer | `0`-`3`. `4` is a walk; the at-bat ends and the field resets. |
+| `strikes` | integer | `0`-`2`. `3` is a strikeout; the at-bat ends and the field resets. |
+| `runners` | object | `{"first": bool, "second": bool, "third": bool}` — base-by-base occupancy. |
+| `currentPitcher` | string | Display name of the pitcher currently on the mound. Distinct from the roster-level `home_pitcher` / `away_pitcher` (starting pitchers). |
+| `currentBatter` | string | Display name of the active hitter. |
+
+<Callout type="info">
+**Detecting half-inning transitions.** No discrete `inning_end` event
+is emitted. To detect the moment a half-inning ends, watch
+`in_play.outs` and `game_period` together across consecutive frames:
+the transition surfaces as `outs` dropping (`2` → `0`, or `1` → `0`
+if a frame was skipped) **and** `game_period` flipping (e.g. `B5` →
+`T6`) — typically in the same frame, occasionally split across two
+consecutive frames. The frame's timestamp is your half-inning-end
+moment.
+</Callout>
 
 ### Freshness
 


### PR DESCRIPTION
## Summary

- Adds the baseball `in_play` block (outs, balls, strikes, runners, currentPitcher, currentBatter) to the public `/api/v1/gamestate` reference — it has been on the wire since the at-bat-state stack landed 2026-05-18 (#844) but was never documented.
- Documents the 0–2 outs contract: `3` is intentionally never emitted as a steady-state value (third out manifests as a transition between frames — outs returns to `0` and `game_period` advances).
- Adds a callout explaining how to detect a half-inning-end moment client-side by watching `in_play.outs` + `game_period` together across consecutive frames.
- Also clarifies that `home_pitcher` / `away_pitcher` are **starting** pitchers (roster-level), distinct from `in_play.currentPitcher` (mid-game).
- Adds the previously-missing `errors_home` / `errors_away` row.

## Why

Customer Mo tê (Sharp+WS) opened SHA-3716 asking whether there's a discrete 3-out / inning-end signal. Engineering investigation found that the data Mo tê needs (`in_play.outs`) is shipping on every gamestate cycle, but the public docs only listed `hits_home/away` + `home_pitcher/away_pitcher` (starting) for baseball. He had no public reference for the field he needed.

This PR closes that documentation gap so the next customer hunting for at-bat state finds it without filing a ticket.

## Inner field casing

Note documented in the PR: inner field names in `in_play` (`currentPitcher`, `currentBatter`) stay **camelCase**, because the Go API's `camelToSnake` transform (`sharp-api-go/websocket.go:1340`) only converts top-level keys — nested object keys pass through unchanged. The docs explicitly call this out so customers know not to expect `current_pitcher`.

## Test plan

- [ ] Vercel preview deploys cleanly
- [ ] Anchor link `#baseball-in_play-block` resolves to the new section
- [ ] Section renders correctly with the Callout component

Refs SHA-3716

Type: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)