### PR TITLE
seo: fix Semrush audit notices (heading anchors, npm 403s, resource links)

### DIFF
--- a/content/de/api-reference/conventions.mdx
+++ b/content/de/api-reference/conventions.mdx
@@ -9,7 +9,7 @@ import { Callout } from 'nextra/components'
 SharpAPI liefert vorhersehbare Antwortstrukturen über jeden REST-Endpoint hinweg. Diese Seite kodifiziert diese Konventionen, damit Sie generische Parser bauen können statt Sonderfälle pro Endpoint.
 
 <Callout type="info">
-  Diese Seite beschreibt die REST-Konventionen. SSE-Streams werden in [SSE Stream](/de/api-reference/stream/) behandelt, und das bidirektionale WebSocket-Protokoll hat seine eigene [AsyncAPI 3.0 Spezifikation](https://docs.sharpapi.io/asyncapi.yaml).
+  Diese Seite beschreibt die REST-Konventionen. SSE-Streams werden in [SSE Stream](/de/api-reference/stream/) behandelt, und das bidirektionale WebSocket-Protokoll hat seine eigene <a href="https://docs.sharpapi.io/asyncapi.yaml" download>AsyncAPI 3.0 Spezifikation</a>.
 </Callout>
 
 ## HTTP-Statuscodes, keine Envelopes
@@ -191,7 +191,7 @@ ETag: "9dc023776c4b382"
 
 ## Maschinenlesbare Quelle der Wahrheit
 
-- REST-Oberfläche: [`openapi.json`](https://docs.sharpapi.io/openapi.json) (OpenAPI 3.1)
-- WebSocket-Oberfläche: [`asyncapi.yaml`](https://docs.sharpapi.io/asyncapi.yaml) (AsyncAPI 3.0)
+- REST-Oberfläche: <a href="https://docs.sharpapi.io/openapi.json" download><code>openapi.json</code></a> (OpenAPI 3.1)
+- WebSocket-Oberfläche: <a href="https://docs.sharpapi.io/asyncapi.yaml" download><code>asyncapi.yaml</code></a> (AsyncAPI 3.0)
 
 Beide Dateien werden als statische Assets veröffentlicht und können in CI verglichen werden. Wenn diese Seite von der Spezifikation abweicht, gewinnt die Spezifikation — die Spezifikation wird vom bereitgestellten Server generiert.

--- a/content/de/api-reference/overview.mdx
+++ b/content/de/api-reference/overview.mdx
@@ -22,7 +22,7 @@ Verwenden Sie immer `api.sharpapi.io` als Basis-URL, nicht `sharpapi.io`.
 
 Die vollständige OpenAPI 3.1-Spezifikation steht zum Import in Tools wie Postman, Insomnia oder Code-Generatoren zur Verfügung:
 
-- [OpenAPI-Spezifikation herunterladen (JSON)](https://docs.sharpapi.io/openapi.json)
+- <a href="https://docs.sharpapi.io/openapi.json" download>OpenAPI-Spezifikation herunterladen (JSON)</a>
 
 <Callout type="info">
 Diese Spezifikation deckt alle Endpoints, Request-/Response-Schemas und Authentifizierungsanforderungen ab.

--- a/content/de/sdks/typescript.mdx
+++ b/content/de/sdks/typescript.mdx
@@ -7,7 +7,7 @@ import { Callout, Tabs } from 'nextra/components'
 # TypeScript SDK
 
 <Callout type="info">
-Installieren Sie das offizielle SDK: `npm install @sharp-api/client` — [npm](https://www.npmjs.com/package/@sharp-api/client) · [GitHub](https://github.com/Sharp-API/sharpapi-ts)
+Installieren Sie das offizielle SDK: `npm install @sharp-api/client` — [GitHub](https://github.com/Sharp-API/sharpapi-ts)
 </Callout>
 
 ## SDK-Schnellstart
@@ -344,7 +344,7 @@ eventSource.onerror = () => {
 
 ### Node.js mit dem `eventsource`-Paket
 
-Für die serverseitige Nutzung installieren Sie das [`eventsource`](https://www.npmjs.com/package/eventsource)-Paket:
+Für die serverseitige Nutzung installieren Sie das [`eventsource`](https://github.com/EventSource/eventsource)-Paket:
 
 ```bash
 npm install eventsource

--- a/content/en/api-reference/conventions.mdx
+++ b/content/en/api-reference/conventions.mdx
@@ -9,7 +9,7 @@ import { Callout } from 'nextra/components'
 SharpAPI returns predictable response shapes across every REST endpoint. This page codifies those conventions so you can build generic parsers, not per-endpoint special cases.
 
 <Callout type="info">
-  This page describes the REST conventions. SSE streams are covered in [SSE Stream](/en/api-reference/stream/), and the bidirectional WebSocket protocol has its own [AsyncAPI 3.0 spec](https://docs.sharpapi.io/asyncapi.yaml).
+  This page describes the REST conventions. SSE streams are covered in [SSE Stream](/en/api-reference/stream/), and the bidirectional WebSocket protocol has its own <a href="https://docs.sharpapi.io/asyncapi.yaml" download>AsyncAPI 3.0 spec</a>.
 </Callout>
 
 ## HTTP status codes, not envelopes
@@ -192,6 +192,6 @@ ETag: "9dc023776c4b382"
 ## Machine-readable source of truth
 
 - REST surface: `openapi.json` from the docs domain root (OpenAPI 3.1)
-- WebSocket surface: [`asyncapi.yaml`](https://docs.sharpapi.io/asyncapi.yaml) (AsyncAPI 3.0)
+- WebSocket surface: <a href="https://docs.sharpapi.io/asyncapi.yaml" download><code>asyncapi.yaml</code></a> (AsyncAPI 3.0)
 
 Both files are published as static assets and can be diffed in CI. If this page drifts from the spec, the spec wins — the spec is generated from the deployed server.

--- a/content/en/api-reference/overview.mdx
+++ b/content/en/api-reference/overview.mdx
@@ -22,7 +22,7 @@ Always use `api.sharpapi.io` as the base URL, not `sharpapi.io`.
 
 The full OpenAPI 3.1 spec is available for import into tools like Postman, Insomnia, or code generators:
 
-- [Download OpenAPI Spec (JSON)](https://docs.sharpapi.io/openapi.json)
+- <a href="https://docs.sharpapi.io/openapi.json" download>Download OpenAPI Spec (JSON)</a>
 
 <Callout type="info">
 This spec covers all endpoints, request/response schemas, and authentication requirements.

--- a/content/en/sdks/typescript.mdx
+++ b/content/en/sdks/typescript.mdx
@@ -7,7 +7,7 @@ import { Callout, Tabs } from 'nextra/components'
 # TypeScript SDK
 
 <Callout type="info">
-Install the official SDK: `npm install @sharp-api/client` — [npm](https://www.npmjs.com/package/@sharp-api/client) · [GitHub](https://github.com/Sharp-API/sharpapi-ts)
+Install the official SDK: `npm install @sharp-api/client` — [GitHub](https://github.com/Sharp-API/sharpapi-ts)
 </Callout>
 
 ## SDK Quick Start
@@ -344,7 +344,7 @@ eventSource.onerror = () => {
 
 ### Node.js with `eventsource` Package
 
-For server-side usage, install the [`eventsource`](https://www.npmjs.com/package/eventsource) package:
+For server-side usage, install the [`eventsource`](https://github.com/EventSource/eventsource) package:
 
 ```bash
 npm install eventsource

--- a/content/es/api-reference/conventions.mdx
+++ b/content/es/api-reference/conventions.mdx
@@ -9,7 +9,7 @@ import { Callout } from 'nextra/components'
 SharpAPI devuelve estructuras de respuesta predecibles en todos los endpoints REST. Esta página recoge dichas convenciones para que puedas crear analizadores genéricos en lugar de casos especiales por endpoint.
 
 <Callout type="info">
-  Esta página describe las convenciones REST. Los flujos SSE se tratan en [Flujo SSE](/es/api-reference/stream/), y el protocolo WebSocket bidireccional dispone de su propia [especificación AsyncAPI 3.0](https://docs.sharpapi.io/asyncapi.yaml).
+  Esta página describe las convenciones REST. Los flujos SSE se tratan en [Flujo SSE](/es/api-reference/stream/), y el protocolo WebSocket bidireccional dispone de su propia <a href="https://docs.sharpapi.io/asyncapi.yaml" download>especificación AsyncAPI 3.0</a>.
 </Callout>
 
 ## Códigos de estado HTTP, no envoltorios
@@ -191,7 +191,7 @@ ETag: "9dc023776c4b382"
 
 ## Fuente de verdad legible por máquina
 
-- Superficie REST: [`openapi.json`](https://docs.sharpapi.io/openapi.json) (OpenAPI 3.1)
-- Superficie WebSocket: [`asyncapi.yaml`](https://docs.sharpapi.io/asyncapi.yaml) (AsyncAPI 3.0)
+- Superficie REST: <a href="https://docs.sharpapi.io/openapi.json" download><code>openapi.json</code></a> (OpenAPI 3.1)
+- Superficie WebSocket: <a href="https://docs.sharpapi.io/asyncapi.yaml" download><code>asyncapi.yaml</code></a> (AsyncAPI 3.0)
 
 Ambos archivos se publican como recursos estáticos y se pueden comparar en CI. Si esta página se desvía de la especificación, la especificación gana: la especificación se genera a partir del servidor desplegado.

--- a/content/es/api-reference/overview.mdx
+++ b/content/es/api-reference/overview.mdx
@@ -22,7 +22,7 @@ Utiliza siempre `api.sharpapi.io` como URL base, no `sharpapi.io`.
 
 La especificación completa de OpenAPI 3.1 está disponible para importarla en herramientas como Postman, Insomnia o generadores de código:
 
-- [Descargar especificación OpenAPI (JSON)](https://docs.sharpapi.io/openapi.json)
+- <a href="https://docs.sharpapi.io/openapi.json" download>Descargar especificación OpenAPI (JSON)</a>
 
 <Callout type="info">
 Esta especificación cubre todos los endpoints, los esquemas de solicitud/respuesta y los requisitos de autenticación.

--- a/content/es/sdks/typescript.mdx
+++ b/content/es/sdks/typescript.mdx
@@ -7,7 +7,7 @@ import { Callout, Tabs } from 'nextra/components'
 # SDK de TypeScript
 
 <Callout type="info">
-Instala el SDK oficial: `npm install @sharp-api/client` — [npm](https://www.npmjs.com/package/@sharp-api/client) · [GitHub](https://github.com/Sharp-API/sharpapi-ts)
+Instala el SDK oficial: `npm install @sharp-api/client` — [GitHub](https://github.com/Sharp-API/sharpapi-ts)
 </Callout>
 
 ## Inicio rápido del SDK
@@ -344,7 +344,7 @@ eventSource.onerror = () => {
 
 ### Node.js con el paquete `eventsource`
 
-Para uso en el lado del servidor, instala el paquete [`eventsource`](https://www.npmjs.com/package/eventsource):
+Para uso en el lado del servidor, instala el paquete [`eventsource`](https://github.com/EventSource/eventsource):
 
 ```bash
 npm install eventsource

--- a/content/pt-BR/api-reference/conventions.mdx
+++ b/content/pt-BR/api-reference/conventions.mdx
@@ -9,7 +9,7 @@ import { Callout } from 'nextra/components'
 A SharpAPI retorna formatos de resposta previsíveis em todos os endpoints REST. Esta página codifica essas convenções para que você possa criar parsers genéricos, em vez de tratar cada endpoint como um caso especial.
 
 <Callout type="info">
-  Esta página descreve as convenções REST. Streams SSE são abordados em [SSE Stream](/pt-BR/api-reference/stream/), e o protocolo WebSocket bidirecional possui sua própria [especificação AsyncAPI 3.0](https://docs.sharpapi.io/asyncapi.yaml).
+  Esta página descreve as convenções REST. Streams SSE são abordados em [SSE Stream](/pt-BR/api-reference/stream/), e o protocolo WebSocket bidirecional possui sua própria <a href="https://docs.sharpapi.io/asyncapi.yaml" download>especificação AsyncAPI 3.0</a>.
 </Callout>
 
 ## Códigos de status HTTP, não envelopes
@@ -191,7 +191,7 @@ ETag: "9dc023776c4b382"
 
 ## Fonte da verdade legível por máquina
 
-- Superfície REST: [`openapi.json`](https://docs.sharpapi.io/openapi.json) (OpenAPI 3.1)
-- Superfície WebSocket: [`asyncapi.yaml`](https://docs.sharpapi.io/asyncapi.yaml) (AsyncAPI 3.0)
+- Superfície REST: <a href="https://docs.sharpapi.io/openapi.json" download><code>openapi.json</code></a> (OpenAPI 3.1)
+- Superfície WebSocket: <a href="https://docs.sharpapi.io/asyncapi.yaml" download><code>asyncapi.yaml</code></a> (AsyncAPI 3.0)
 
 Ambos os arquivos são publicados como assets estáticos e podem ser comparados (diff) em CI. Se esta página divergir da especificação, a especificação prevalece — a especificação é gerada a partir do servidor implantado.

--- a/content/pt-BR/api-reference/overview.mdx
+++ b/content/pt-BR/api-reference/overview.mdx
@@ -22,7 +22,7 @@ Sempre use `api.sharpapi.io` como URL base, não `sharpapi.io`.
 
 A especificação completa OpenAPI 3.1 está disponível para importação em ferramentas como Postman, Insomnia ou geradores de código:
 
-- [Baixar Especificação OpenAPI (JSON)](https://docs.sharpapi.io/openapi.json)
+- <a href="https://docs.sharpapi.io/openapi.json" download>Baixar Especificação OpenAPI (JSON)</a>
 
 <Callout type="info">
 Esta especificação cobre todos os endpoints, esquemas de requisição/resposta e requisitos de autenticação.

--- a/content/pt-BR/sdks/typescript.mdx
+++ b/content/pt-BR/sdks/typescript.mdx
@@ -7,7 +7,7 @@ import { Callout, Tabs } from 'nextra/components'
 # SDK TypeScript
 
 <Callout type="info">
-Instale o SDK oficial: `npm install @sharp-api/client` — [npm](https://www.npmjs.com/package/@sharp-api/client) · [GitHub](https://github.com/Sharp-API/sharpapi-ts)
+Instale o SDK oficial: `npm install @sharp-api/client` — [GitHub](https://github.com/Sharp-API/sharpapi-ts)
 </Callout>
 
 ## Início Rápido com o SDK
@@ -344,7 +344,7 @@ eventSource.onerror = () => {
 
 ### Node.js com o pacote `eventsource`
 
-Para uso no servidor, instale o pacote [`eventsource`](https://www.npmjs.com/package/eventsource):
+Para uso no servidor, instale o pacote [`eventsource`](https://github.com/EventSource/eventsource):
 
 ```bash
 npm install eventsource

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "packageManager": "pnpm@11.0.9",
   "scripts": {
     "dev": "next dev -H 0.0.0.0 -p 3002",
-    "build": "node scripts/stamp-openapi.mjs && node scripts/generate-sitemap.mjs && next build && node scripts/fix-locale-links.mjs && pagefind --site out --output-subdir _pagefind",
+    "build": "node scripts/stamp-openapi.mjs && node scripts/generate-sitemap.mjs && next build && node scripts/fix-locale-links.mjs && node scripts/fix-subheading-anchors.mjs && pagefind --site out --output-subdir _pagefind",
     "start": "next start",
     "typecheck": "tsc --noEmit",
     "check-links": "./scripts/check-links.sh"

--- a/scripts/fix-subheading-anchors.mjs
+++ b/scripts/fix-subheading-anchors.mjs
@@ -1,0 +1,82 @@
+/**
+ * Post-build script: inject sr-only text content into Nextra's empty heading
+ * permalink anchors so SEO crawlers see anchor text.
+ *
+ * Nextra theme renders each heading permalink as
+ *   <a href="#slug" class="...subheading-anchor" aria-label="Permalink for this section"></a>
+ *
+ * Semrush counts visible text only (not aria-label) when checking for anchor
+ * text, so it flags every one of these as "Links with no anchor text". On a
+ * doc site with hundreds of headings this dominates the audit (3,323 instances
+ * across 220 pages at 2026-05-27).
+ *
+ * The fix injects a visually-hidden <span> with the same text as the aria-label
+ * so the anchor has a real text node. CSS keeps it invisible to sighted users;
+ * the existing CSS `::before` pseudo-element that renders the visible `#` glyph
+ * is unaffected.
+ */
+
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+const OUT_DIR = join(import.meta.dirname, '..', 'out');
+
+// Standard sr-only inline style — independent of Tailwind/utility CSS bundles
+const SR_ONLY = 'position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0';
+
+// Match empty <a ... class="...subheading-anchor..." ... aria-label="X"></a>
+// Allow attribute order to vary and tolerate other classes alongside subheading-anchor.
+const ANCHOR_RE = /<a\b([^>]*\bclass="[^"]*\bsubheading-anchor\b[^"]*"[^>]*)><\/a>/g;
+
+function getAttr(attrs, name) {
+  const m = attrs.match(new RegExp(`\\b${name}="([^"]*)"`));
+  return m ? m[1] : null;
+}
+
+function injectAnchorText(html) {
+  let count = 0;
+  const fixed = html.replace(ANCHOR_RE, (match, attrs) => {
+    const label = getAttr(attrs, 'aria-label') || 'Permalink for this section';
+    count++;
+    return `<a${attrs}><span style="${SR_ONLY}">${label}</span></a>`;
+  });
+  return { fixed, count };
+}
+
+async function getHtmlFiles(dir) {
+  const files = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await getHtmlFiles(full)));
+    } else if (entry.name.endsWith('.html')) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+async function main() {
+  const files = await getHtmlFiles(OUT_DIR);
+  let totalInjected = 0;
+  let pagesTouched = 0;
+
+  for (const file of files) {
+    const original = await readFile(file, 'utf8');
+    const { fixed, count } = injectAnchorText(original);
+    if (count > 0) {
+      await writeFile(file, fixed, 'utf8');
+      totalInjected += count;
+      pagesTouched++;
+      console.log(`  ${relative(OUT_DIR, file)}: ${count} anchors`);
+    }
+  }
+
+  console.log(`\nInjected anchor text into ${totalInjected} permalinks across ${pagesTouched} pages (${files.length} HTML files scanned)`);
+}
+
+main().catch((err) => {
+  console.error('fix-subheading-anchors failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Closes 3 of 5 Semrush Site Audit notice categories that the 2026-05-21 crawl attributed to docs.sharpapi.io:
  - **Links with no anchor text**: 3,103 of 3,323
  - **External pages with 403**: all 8 (npm pages)
  - **Resources formatted as page links**: all 8 (OpenAPI / AsyncAPI specs)
- Plus a tiny refactor: the postbuild HTML rewrites now have a sibling for anchor text — same pattern as `fix-locale-links.mjs`.

## What changed

### 1. `scripts/fix-subheading-anchors.mjs` (new) + `package.json`
Nextra renders every heading permalink as
```html
<a href="#slug" class="subheading-anchor" aria-label="Permalink for this section"></a>
```
Semrush counts only visible text content for the no-anchor-text check — `aria-label` doesn't satisfy it. With ~15 headings per page × 220 pages, this was 3,103 instances and dominated the audit. The postbuild walks `out/**/*.html` and injects a visually-hidden `<span>` carrying the aria-label text into every empty anchor. Inline sr-only style so it works without depending on any utility CSS bundle.

Wired into `build` right after the existing `fix-locale-links.mjs`. Verified end-to-end on a clean local build: ``Injected anchor text into 3,103 permalinks across 220 pages``.

### 2. `content/{en,de,es,pt-BR}/sdks/typescript.mdx`
npmjs.com returns 403 to Semrush's crawler (it blocks bot user-agents). Two unique URLs × 4 locales = 8 notice instances. Both URLs were avoidable:
- `@sharp-api/client` npm link → removed (GitHub link already sat next to it)
- `eventsource` → repointed to `github.com/EventSource/eventsource`

### 3. `content/{en,de,es,pt-BR}/api-reference/{conventions,overview}.mdx`
Static spec files (`openapi.json`, `asyncapi.yaml`) were linked with plain markdown so Semrush classified them as "Resources formatted as page links." Converted each occurrence to inline HTML `<a href="..." download>...</a>` so the link advertises that it's a file resource.

## Out of scope (left as Semrush "Notices")
- **2 hreflang language mismatches** on `/de/sdks/{python,typescript}`. The German pages are partially translated (52 lines differ from EN vs es=62, pt-BR=58) but ~70% of each SDK page is code blocks with English variable names and comments. Pushing past the language-detection threshold requires expanding the German prose, not a routing change.
- **4 low-semantic-HTML notices** on `/sdks/typescript` (× 4 locales). Structural to a code-heavy SDK reference page — not worth a content rewrite to flip a NOTICE.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run build` end-to-end — postbuild script reports 3,103 anchors injected across 220 pages; pagefind indexed 221 pages, 4 languages
- [x] Spot-check rebuilt `out/en/api-reference/websocket/index.html` — 32 `subheading-anchor` tags now contain an sr-only `<span>` and 0 are empty
- [ ] After deploy: re-run Semrush Site Audit on sharpapi.io — confirm no-anchor-text drops to a small residual (Semrush's count was 3,323 on 2026-05-21; new content added since may add a few)
- [ ] Confirm 0 external 403s on the typescript SDK pages
- [ ] Confirm 0 resources-as-page-links on conventions + overview

🤖 Generated with [Claude Code](https://claude.com/claude-code)