### PR TITLE
ci: notify Paperclip on workflow failure (SHA-1698)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -79,6 +79,43 @@ jobs:
           echo "## Preview Deployment" >> $GITHUB_STEP_SUMMARY
           echo "**URL**: $DEPLOYMENT_URL" >> $GITHUB_STEP_SUMMARY
 
+      - name: Notify on failure
+        if: failure()
+        env:
+          PAPERCLIP_API_URL: ${{ secrets.PAPERCLIP_API_URL }}
+          PAPERCLIP_API_KEY: ${{ secrets.PAPERCLIP_API_KEY }}
+        run: |
+          echo "::error::Deployment to dev preview failed. Check the logs above for details."
+
+          # Extract Paperclip issue identifier from branch name or commit message
+          COMMIT_MSG=$(git log -1 --format=%s ${{ github.sha }})
+          ISSUE_ID=$(echo "$COMMIT_MSG" | grep -oP 'SHA-\d+' | head -1)
+
+          # If no issue in commit message, check the merge branch name
+          if [ -z "$ISSUE_ID" ]; then
+            ISSUE_ID=$(echo "$COMMIT_MSG" | grep -oP 'paperclip/(SHA-\d+)' | head -1 | sed 's|paperclip/||')
+          fi
+
+          if [ -n "$ISSUE_ID" ] && [ -n "$PAPERCLIP_API_URL" ] && [ -n "$PAPERCLIP_API_KEY" ]; then
+            # Comment on the existing issue
+            COMMENT="## CI Deploy Failed\n\n**Workflow**: ${{ github.workflow }}\n**Run**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n**Commit**: \`${{ github.sha }}\`\n\nThe deploy to prod failed. Check the CI logs and fix the issue. Do NOT mark this issue as done until a successful deploy is verified."
+            curl -sf -X PATCH "$PAPERCLIP_API_URL/issues/$ISSUE_ID" \
+              -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n --arg status "blocked" --arg comment "$COMMENT" '{status: $status, comment: $comment}')" || true
+            echo "Commented on Paperclip issue $ISSUE_ID"
+          elif [ -n "$PAPERCLIP_API_URL" ] && [ -n "$PAPERCLIP_API_KEY" ]; then
+            # No issue found — create one assigned to Coordinator for triage
+            curl -sf -X POST "$PAPERCLIP_API_URL/companies/953ff6b0-4d1b-4007-9859-8cb0a53629f6/issues" \
+              -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n \
+                --arg title "CI Failed: docs.sharpapi.io (${{ github.ref_name }})" \
+                --arg desc "GitHub Actions workflow **${{ github.workflow }}** failed.\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\nCommit: \`$(git log -1 --format='%h %s' ${{ github.sha }})\`\n\nInvestigate and fix." \
+                '{title: $title, description: $desc, status: "todo", priority: "critical", assigneeAgentId: "3a976364-1186-4c30-a136-bba410c2209c"}')" || true
+            echo "Created Paperclip issue for deploy failure"
+          fi
+
   health-check:
     name: Health Check
     needs: deploy-preview

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -118,6 +118,44 @@ jobs:
           echo "**URL**: ${{ env.PRODUCTION_URL }}" >> $GITHUB_STEP_SUMMARY
           echo "**Deployment**: $DEPLOYMENT_URL" >> $GITHUB_STEP_SUMMARY
 
+      - name: Notify on failure
+        if: failure()
+        env:
+          PAPERCLIP_API_URL: ${{ secrets.PAPERCLIP_API_URL }}
+          PAPERCLIP_API_KEY: ${{ secrets.PAPERCLIP_API_KEY }}
+        run: |
+          echo "::error::Deployment to prod failed. Check the logs above for details."
+          echo "To rollback, run this workflow manually with 'rollback' set to true."
+
+          # Extract Paperclip issue identifier from branch name or commit message
+          COMMIT_MSG=$(git log -1 --format=%s ${{ github.sha }})
+          ISSUE_ID=$(echo "$COMMIT_MSG" | grep -oP 'SHA-\d+' | head -1)
+
+          # If no issue in commit message, check the merge branch name
+          if [ -z "$ISSUE_ID" ]; then
+            ISSUE_ID=$(echo "$COMMIT_MSG" | grep -oP 'paperclip/(SHA-\d+)' | head -1 | sed 's|paperclip/||')
+          fi
+
+          if [ -n "$ISSUE_ID" ] && [ -n "$PAPERCLIP_API_URL" ] && [ -n "$PAPERCLIP_API_KEY" ]; then
+            # Comment on the existing issue
+            COMMENT="## CI Deploy Failed\n\n**Workflow**: ${{ github.workflow }}\n**Run**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n**Commit**: \`${{ github.sha }}\`\n\nThe deploy to prod failed. Check the CI logs and fix the issue. Do NOT mark this issue as done until a successful deploy is verified."
+            curl -sf -X PATCH "$PAPERCLIP_API_URL/issues/$ISSUE_ID" \
+              -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n --arg status "blocked" --arg comment "$COMMENT" '{status: $status, comment: $comment}')" || true
+            echo "Commented on Paperclip issue $ISSUE_ID"
+          elif [ -n "$PAPERCLIP_API_URL" ] && [ -n "$PAPERCLIP_API_KEY" ]; then
+            # No issue found — create one assigned to Coordinator for triage
+            curl -sf -X POST "$PAPERCLIP_API_URL/companies/953ff6b0-4d1b-4007-9859-8cb0a53629f6/issues" \
+              -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n \
+                --arg title "CI Failed: docs.sharpapi.io (${{ github.ref_name }})" \
+                --arg desc "GitHub Actions workflow **${{ github.workflow }}** failed.\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\nCommit: \`$(git log -1 --format='%h %s' ${{ github.sha }})\`\n\nInvestigate and fix." \
+                '{title: $title, description: $desc, status: "todo", priority: "critical", assigneeAgentId: "3a976364-1186-4c30-a136-bba410c2209c"}')" || true
+            echo "Created Paperclip issue for deploy failure"
+          fi
+
   rollback:
     name: Rollback
     runs-on: ubuntu-latest

--- a/.github/workflows/upstream-notify.yml
+++ b/.github/workflows/upstream-notify.yml
@@ -93,3 +93,40 @@ jobs:
             echo "**Commit**: ${{ github.event.client_payload.commit }}"
             echo "**Changed**: ${{ github.event.client_payload.changed_files }}"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Notify on failure
+        if: failure()
+        env:
+          PAPERCLIP_API_URL: ${{ secrets.PAPERCLIP_API_URL }}
+          PAPERCLIP_API_KEY: ${{ secrets.PAPERCLIP_API_KEY }}
+        run: |
+          echo "::error::Upstream notification run failed. Check the logs above for details."
+
+          # Extract Paperclip issue identifier from branch name or commit message
+          COMMIT_MSG=$(git log -1 --format=%s ${{ github.sha }})
+          ISSUE_ID=$(echo "$COMMIT_MSG" | grep -oP 'SHA-\d+' | head -1)
+
+          # If no issue in commit message, check the merge branch name
+          if [ -z "$ISSUE_ID" ]; then
+            ISSUE_ID=$(echo "$COMMIT_MSG" | grep -oP 'paperclip/(SHA-\d+)' | head -1 | sed 's|paperclip/||')
+          fi
+
+          if [ -n "$ISSUE_ID" ] && [ -n "$PAPERCLIP_API_URL" ] && [ -n "$PAPERCLIP_API_KEY" ]; then
+            # Comment on the existing issue
+            COMMENT="## CI Deploy Failed\n\n**Workflow**: ${{ github.workflow }}\n**Run**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n**Commit**: \`${{ github.sha }}\`\n\nThe deploy to prod failed. Check the CI logs and fix the issue. Do NOT mark this issue as done until a successful deploy is verified."
+            curl -sf -X PATCH "$PAPERCLIP_API_URL/issues/$ISSUE_ID" \
+              -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n --arg status "blocked" --arg comment "$COMMENT" '{status: $status, comment: $comment}')" || true
+            echo "Commented on Paperclip issue $ISSUE_ID"
+          elif [ -n "$PAPERCLIP_API_URL" ] && [ -n "$PAPERCLIP_API_KEY" ]; then
+            # No issue found — create one assigned to Coordinator for triage
+            curl -sf -X POST "$PAPERCLIP_API_URL/companies/953ff6b0-4d1b-4007-9859-8cb0a53629f6/issues" \
+              -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n \
+                --arg title "CI Failed: docs.sharpapi.io (${{ github.ref_name }})" \
+                --arg desc "GitHub Actions workflow **${{ github.workflow }}** failed.\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\nCommit: \`$(git log -1 --format='%h %s' ${{ github.sha }})\`\n\nInvestigate and fix." \
+                '{title: $title, description: $desc, status: "todo", priority: "critical", assigneeAgentId: "3a976364-1186-4c30-a136-bba410c2209c"}')" || true
+            echo "Created Paperclip issue for deploy failure"
+          fi


### PR DESCRIPTION
Adds a `Notify on failure` step (`if: failure()`) to the primary work job of three workflows:

- `.github/workflows/deploy-dev.yml` — added to the `deploy-preview` job (real deploy step). No rollback hint (no rollback path for dev preview); failure text says deploy to dev preview failed.
- `.github/workflows/deploy-prod.yml` — added to the `deploy-production` job. Keeps the rollback-hint echo (this is the only workflow with a rollback path).
- `.github/workflows/upstream-notify.yml` — added to the `upsert-review-issue` job. Failure text reflects an upstream-notification run.

The Paperclip PATCH-existing-issue + POST-new-issue curl logic is byte-identical to the api-adapters `deploy-prod` reference (company id `953ff6b0-4d1b-4007-9859-8cb0a53629f6`, `SHA-NNNN` extraction, `if: failure()`). Per-repo adjustments: fallback issue title `CI Failed: docs.sharpapi.io (${{ github.ref_name }})` and `assigneeAgentId: 3a976364-1186-4c30-a136-bba410c2209c`.

All three files validated with `yaml.safe_load`.

Fixes SHA-1698

Type: ci