### PR TITLE
seo: fix logo nested-anchor (224 no-anchor-text links)

### DIFF
--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -74,7 +74,7 @@ export default async function LangLayout({ children, params }) {
             feedback={{ content: null }}
             editLink={null}
             navbar={
-              <Navbar logo={logo}>
+              <Navbar logo={logo} logoLink={false}>
                 {navbarExtra}
               </Navbar>
             }


### PR DESCRIPTION
Fixes the **224 "links with no anchor text"** notices in the Semrush site audit (campaign 29018595).

## Root cause
The navbar `logo` is a `<Link href="https://sharpapi.io">`, passed into Nextra's `<Navbar>`. By default Nextra wraps the logo in **its own** `<a href="/{lang}/" aria-label="Home page">`. That produces an `<a>` nested inside an `<a>` — invalid HTML. Browsers split nested anchors, leaving the **outer** locale-home link (`/en/`, `/de/`, …) with **no content / no anchor text**. Semrush flagged it once per docs page across all locales = 224 links. It is categorized under **AI Search** because LLM crawlers rely on anchor text to understand link destinations.

## Fix
```diff
- <Navbar logo={logo}>
+ <Navbar logo={logo} logoLink={false}>
```
With `logoLink={false}`, Nextra renders a plain `<div>` wrapper (verified in installed `nextra-theme-docs` source). Our `logo` `<Link>` becomes the **single valid anchor**, with real anchor text (`img alt="SharpAPI"` + `<span>SharpAPI</span>`), still pointing to the marketing site as intended.

## Impact
- Removes invalid nested-anchor HTML site-wide (header is shared)
- Resolves all 224 Semrush no-anchor-text notices in one change
- Improves AI-search citability; no visual change to the logo

## Verification
- `npm run typecheck` passes clean
- Single valid anchor confirmed: `<div><a href="https://sharpapi.io"><img alt="SharpAPI"><span>SharpAPI</span></a></div>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)