### PR TITLE
seo: add intro prose to TypeScript SDK pages (semantic HTML + hreflang)

### DIFF
--- a/content/de/sdks/typescript.mdx
+++ b/content/de/sdks/typescript.mdx
@@ -6,6 +6,8 @@ import { Callout, Tabs } from 'nextra/components'
 
 # TypeScript SDK
 
+Das offizielle TypeScript-SDK `@sharp-api/client` bietet typisierten Zugriff auf jeden SharpAPI-Endpoint — mit SSE-Streaming, Zod-Validierung und vollständiger IDE-Autovervollständigung von Anfang an.
+
 <Callout type="info">
 Installieren Sie das offizielle SDK: `npm install @sharp-api/client` — [GitHub](https://github.com/Sharp-API/sharpapi-ts)
 </Callout>

--- a/content/en/sdks/typescript.mdx
+++ b/content/en/sdks/typescript.mdx
@@ -6,6 +6,8 @@ import { Callout, Tabs } from 'nextra/components'
 
 # TypeScript SDK
 
+The official `@sharp-api/client` TypeScript SDK gives you typed access to every SharpAPI endpoint, with SSE streaming, Zod validation, and full IDE autocomplete out of the box.
+
 <Callout type="info">
 Install the official SDK: `npm install @sharp-api/client` — [GitHub](https://github.com/Sharp-API/sharpapi-ts)
 </Callout>

--- a/content/es/sdks/typescript.mdx
+++ b/content/es/sdks/typescript.mdx
@@ -6,6 +6,8 @@ import { Callout, Tabs } from 'nextra/components'
 
 # SDK de TypeScript
 
+El SDK oficial de TypeScript `@sharp-api/client` te da acceso tipado a todos los endpoints de SharpAPI, con streaming SSE, validación Zod y autocompletado completo del IDE desde el primer momento.
+
 <Callout type="info">
 Instala el SDK oficial: `npm install @sharp-api/client` — [GitHub](https://github.com/Sharp-API/sharpapi-ts)
 </Callout>

--- a/content/pt-BR/sdks/typescript.mdx
+++ b/content/pt-BR/sdks/typescript.mdx
@@ -6,6 +6,8 @@ import { Callout, Tabs } from 'nextra/components'
 
 # SDK TypeScript
 
+O SDK TypeScript oficial `@sharp-api/client` oferece acesso tipado a todos os endpoints da SharpAPI, com streaming SSE, validação Zod e autocomplete completo na IDE desde o início.
+
 <Callout type="info">
 Instale o SDK oficial: `npm install @sharp-api/client` — [GitHub](https://github.com/Sharp-API/sharpapi-ts)
 </Callout>


### PR DESCRIPTION
Second pass on the Semrush audit (campaign 29018595) cleanup — companion to #252.

## What
Adds a one-sentence, locale-correct **intro paragraph** after the H1 on the TypeScript SDK page in all 4 locales (en/de/es/pt-BR). The page previously went H1 → Callout → large code block with no lead prose, unlike the Python SDK page which has an intro.

## Why
Two Semrush notices trace to the same root cause — these pages are **code-block dominant**, so the prose-to-code ratio is very low:
- **6 pages have low semantic HTML usage** — the TS SDK page in all 4 locales is in this set.
- **3 pages have hreflang language mismatch** — `de/sdks/typescript` detected as `en` despite German prose, because the code blocks outweigh the text.

A factual lead sentence raises the prose ratio, improves **AI citability** (a clean quotable summary for LLMs), and brings the page in line with the Python SDK page.

## Honest scope note
These are inherently code-heavy pages, so this nudges the signals in the right direction but may not fully clear the Notices on its own. The remaining audit items are **not** in this repo:
- 12 flags (missing alt, missing meta description, uncached JS/CSS, one-incoming-link) are all on **status.sharpapi.io** (third-party hosted status page).
- `7 resources formatted as page link` = intentional links to `/openapi.json`.
- `pt-BR/api-reference/sportsbooks` hreflang flag is a data-table/JSON-dominance false positive on correctly-translated content.

## Verification
- `npm run typecheck` passes
- Plain MDX paragraphs with inline code, consistent placement across locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)