### PR TITLE
docs(i18n): translate Python SDK code comments (de/es/pt-BR)

### DIFF
--- a/content/de/sdks/python.mdx
+++ b/content/de/sdks/python.mdx
@@ -29,21 +29,21 @@ from sharpapi import SharpAPI
 
 client = SharpAPI("sk_live_xxx")
 
-# Arbitrage opportunities
+# Arbitrage-Gelegenheiten
 arbs = client.arbitrage.get(min_profit=1.0, league="nba")
 for arb in arbs.data:
     print(f"{arb.profit_percent:.2f}% profit — {arb.event_name}")
     for leg in arb.legs:
         print(f"  {leg.sportsbook}: {leg.selection} @ {leg.odds_american} ({leg.stake_percent:.1f}%)")
 
-# +EV opportunities
+# +EV-Gelegenheiten
 evs = client.ev.get(min_ev=3.0, sport="basketball")
 for opp in evs.data:
     print(f"+{opp.ev_percentage:.1f}% EV on {opp.selection} @ {opp.sportsbook}")
     if opp.kelly_percent:
         print(f"  Kelly: {opp.kelly_percent:.2f}%, Confidence: {opp.confidence_score}")
 
-# Best odds across sportsbooks
+# Beste Quoten über alle Sportsbooks
 odds = client.odds.best(league="nba", market="moneyline")
 for line in odds.data:
     print(f"{line.home_team} vs {line.away_team}: {line.selection} {line.odds_american}")
@@ -54,16 +54,16 @@ for line in odds.data:
 ### Odds
 
 ```python
-# Full snapshot with filters
+# Vollständiger Snapshot mit Filtern
 client.odds.get(sport="basketball", league="nba", limit=100)
 
-# Best odds per selection across books
+# Beste Quoten pro Auswahl über alle Sportsbooks
 client.odds.best(league="nfl", market="moneyline")
 
-# Side-by-side comparison for an event
+# Direkter Vergleich für ein Event
 client.odds.comparison(event_id="evt_abc123")
 
-# Batch lookup
+# Batch-Abfrage
 client.odds.batch(event_ids=["evt_abc123", "evt_def456"])
 ```
 
@@ -216,7 +216,7 @@ def on_snapshot(data):
 
 @stream.on("odds:update")
 def on_update(data):
-    # DELTA — merge into local state
+    # DELTA — in den lokalen Zustand einpflegen
     for book, odds_list in data.items():
         if isinstance(odds_list, list):
             for odds in odds_list:
@@ -238,16 +238,16 @@ stream.connect()
 ### Stream-Kanäle
 
 ```python
-# Odds only
+# Nur Quoten
 client.stream.odds(league="nba")
 
-# Opportunities only (EV + arb + middles)
+# Nur Gelegenheiten (EV + Arb + Middles)
 client.stream.opportunities(min_ev=3.0)
 
-# Everything
+# Alles
 client.stream.all(sport="basketball")
 
-# Single event
+# Einzelnes Event
 client.stream.event("evt_abc123")
 ```
 
@@ -258,7 +258,7 @@ Jede Gelegenheit enthält Metadaten zur Veraltung:
 ```python
 arbs = client.arbitrage.get()
 for arb in arbs.data:
-    # Skip stale or suspicious opportunities
+    # Veraltete oder verdächtige Gelegenheiten überspringen
     if arb.possibly_stale:
         print(f"Stale ({arb.oldest_odds_age_seconds}s old)")
         continue
@@ -317,7 +317,7 @@ decimal_to_american(2.5)        # 150
 ```python
 with SharpAPI("sk_live_xxx") as client:
     arbs = client.arbitrage.get()
-    # HTTP client automatically closed on exit
+    # HTTP-Client wird beim Beenden automatisch geschlossen
 ```
 
 ## Typsicherheit
@@ -327,7 +327,7 @@ Alle Antworten verwenden Pydantic-Modelle mit vollständigen Typhinweisen:
 ```python
 from sharpapi import EVOpportunity, ArbitrageOpportunity
 
-# IDE autocomplete works on all fields
+# IDE-Autovervollständigung funktioniert für alle Felder
 arbs = client.arbitrage.get()
 arb: ArbitrageOpportunity = arbs.data[0]
 arb.profit_percent   # float

--- a/content/es/sdks/python.mdx
+++ b/content/es/sdks/python.mdx
@@ -29,21 +29,21 @@ from sharpapi import SharpAPI
 
 client = SharpAPI("sk_live_xxx")
 
-# Arbitrage opportunities
+# Oportunidades de arbitraje
 arbs = client.arbitrage.get(min_profit=1.0, league="nba")
 for arb in arbs.data:
     print(f"{arb.profit_percent:.2f}% profit — {arb.event_name}")
     for leg in arb.legs:
         print(f"  {leg.sportsbook}: {leg.selection} @ {leg.odds_american} ({leg.stake_percent:.1f}%)")
 
-# +EV opportunities
+# Oportunidades +EV
 evs = client.ev.get(min_ev=3.0, sport="basketball")
 for opp in evs.data:
     print(f"+{opp.ev_percentage:.1f}% EV on {opp.selection} @ {opp.sportsbook}")
     if opp.kelly_percent:
         print(f"  Kelly: {opp.kelly_percent:.2f}%, Confidence: {opp.confidence_score}")
 
-# Best odds across sportsbooks
+# Mejores cuotas entre casas de apuestas
 odds = client.odds.best(league="nba", market="moneyline")
 for line in odds.data:
     print(f"{line.home_team} vs {line.away_team}: {line.selection} {line.odds_american}")
@@ -54,16 +54,16 @@ for line in odds.data:
 ### Odds
 
 ```python
-# Full snapshot with filters
+# Snapshot completo con filtros
 client.odds.get(sport="basketball", league="nba", limit=100)
 
-# Best odds per selection across books
+# Mejores cuotas por selección entre casas
 client.odds.best(league="nfl", market="moneyline")
 
-# Side-by-side comparison for an event
+# Comparación lado a lado para un evento
 client.odds.comparison(event_id="evt_abc123")
 
-# Batch lookup
+# Consulta por lotes
 client.odds.batch(event_ids=["evt_abc123", "evt_def456"])
 ```
 
@@ -216,7 +216,7 @@ def on_snapshot(data):
 
 @stream.on("odds:update")
 def on_update(data):
-    # DELTA — merge into local state
+    # DELTA — fusionar en el estado local
     for book, odds_list in data.items():
         if isinstance(odds_list, list):
             for odds in odds_list:
@@ -238,16 +238,16 @@ stream.connect()
 ### Canales de streaming
 
 ```python
-# Odds only
+# Solo cuotas
 client.stream.odds(league="nba")
 
-# Opportunities only (EV + arb + middles)
+# Solo oportunidades (EV + arb + middles)
 client.stream.opportunities(min_ev=3.0)
 
-# Everything
+# Todo
 client.stream.all(sport="basketball")
 
-# Single event
+# Evento único
 client.stream.event("evt_abc123")
 ```
 
@@ -258,7 +258,7 @@ Cada oportunidad incluye metadatos de obsolescencia (staleness):
 ```python
 arbs = client.arbitrage.get()
 for arb in arbs.data:
-    # Skip stale or suspicious opportunities
+    # Omitir oportunidades obsoletas o sospechosas
     if arb.possibly_stale:
         print(f"Stale ({arb.oldest_odds_age_seconds}s old)")
         continue
@@ -317,7 +317,7 @@ decimal_to_american(2.5)        # 150
 ```python
 with SharpAPI("sk_live_xxx") as client:
     arbs = client.arbitrage.get()
-    # HTTP client automatically closed on exit
+    # El cliente HTTP se cierra automáticamente al salir
 ```
 
 ## Seguridad de tipos
@@ -327,7 +327,7 @@ Todas las respuestas usan modelos Pydantic con anotaciones de tipo completas:
 ```python
 from sharpapi import EVOpportunity, ArbitrageOpportunity
 
-# IDE autocomplete works on all fields
+# El autocompletado del IDE funciona en todos los campos
 arbs = client.arbitrage.get()
 arb: ArbitrageOpportunity = arbs.data[0]
 arb.profit_percent   # float

--- a/content/pt-BR/sdks/python.mdx
+++ b/content/pt-BR/sdks/python.mdx
@@ -29,21 +29,21 @@ from sharpapi import SharpAPI
 
 client = SharpAPI("sk_live_xxx")
 
-# Arbitrage opportunities
+# Oportunidades de arbitragem
 arbs = client.arbitrage.get(min_profit=1.0, league="nba")
 for arb in arbs.data:
     print(f"{arb.profit_percent:.2f}% profit — {arb.event_name}")
     for leg in arb.legs:
         print(f"  {leg.sportsbook}: {leg.selection} @ {leg.odds_american} ({leg.stake_percent:.1f}%)")
 
-# +EV opportunities
+# Oportunidades +EV
 evs = client.ev.get(min_ev=3.0, sport="basketball")
 for opp in evs.data:
     print(f"+{opp.ev_percentage:.1f}% EV on {opp.selection} @ {opp.sportsbook}")
     if opp.kelly_percent:
         print(f"  Kelly: {opp.kelly_percent:.2f}%, Confidence: {opp.confidence_score}")
 
-# Best odds across sportsbooks
+# Melhores odds entre casas de apostas
 odds = client.odds.best(league="nba", market="moneyline")
 for line in odds.data:
     print(f"{line.home_team} vs {line.away_team}: {line.selection} {line.odds_american}")
@@ -54,16 +54,16 @@ for line in odds.data:
 ### Odds
 
 ```python
-# Full snapshot with filters
+# Snapshot completo com filtros
 client.odds.get(sport="basketball", league="nba", limit=100)
 
-# Best odds per selection across books
+# Melhores odds por seleção entre casas
 client.odds.best(league="nfl", market="moneyline")
 
-# Side-by-side comparison for an event
+# Comparação lado a lado para um evento
 client.odds.comparison(event_id="evt_abc123")
 
-# Batch lookup
+# Consulta em lote
 client.odds.batch(event_ids=["evt_abc123", "evt_def456"])
 ```
 
@@ -216,7 +216,7 @@ def on_snapshot(data):
 
 @stream.on("odds:update")
 def on_update(data):
-    # DELTA — merge into local state
+    # DELTA — mesclar no estado local
     for book, odds_list in data.items():
         if isinstance(odds_list, list):
             for odds in odds_list:
@@ -238,16 +238,16 @@ stream.connect()
 ### Canais de Stream
 
 ```python
-# Odds only
+# Apenas odds
 client.stream.odds(league="nba")
 
-# Opportunities only (EV + arb + middles)
+# Apenas oportunidades (EV + arb + middles)
 client.stream.opportunities(min_ev=3.0)
 
-# Everything
+# Tudo
 client.stream.all(sport="basketball")
 
-# Single event
+# Evento único
 client.stream.event("evt_abc123")
 ```
 
@@ -258,7 +258,7 @@ Toda oportunidade inclui metadados de obsolescência:
 ```python
 arbs = client.arbitrage.get()
 for arb in arbs.data:
-    # Skip stale or suspicious opportunities
+    # Ignorar oportunidades obsoletas ou suspeitas
     if arb.possibly_stale:
         print(f"Stale ({arb.oldest_odds_age_seconds}s old)")
         continue
@@ -317,7 +317,7 @@ decimal_to_american(2.5)        # 150
 ```python
 with SharpAPI("sk_live_xxx") as client:
     arbs = client.arbitrage.get()
-    # HTTP client automatically closed on exit
+    # O cliente HTTP é fechado automaticamente ao sair
 ```
 
 ## Segurança de Tipos
@@ -327,7 +327,7 @@ Todas as respostas usam modelos Pydantic com type hints completos:
 ```python
 from sharpapi import EVOpportunity, ArbitrageOpportunity
 
-# IDE autocomplete works on all fields
+# O autocomplete da IDE funciona em todos os campos
 arbs = client.arbitrage.get()
 arb: ArbitrageOpportunity = arbs.data[0]
 arb.profit_percent   # float


### PR DESCRIPTION
Completes localization of the Python SDK pages.

## What
The `de/es/pt-BR` Python SDK pages had translated prose and headings but **15 English code comments** left untranslated inside the code blocks (copied from the EN source and never localized) — e.g. `# Arbitrage opportunities`, `# Best odds across sportsbooks`, `# IDE autocomplete works on all fields`. A developer reading the localized page sees English mid-code.

This translates all 15 in each of the three locales, matching existing per-locale terminology (Quoten / cuotas / odds, Gelegenheiten / oportunidades / oportunidades, etc.). Indentation and code semantics untouched — comments only.

## Notes
- Found while auditing the Semrush hreflang notice. Note: this is genuine localization hygiene; it will **not** clear the hreflang notice on its own (Semrush reads the English code *identifiers*, not comments — confirmed by `de/typescript` being fully German yet still flagged). Filed separately as the right thing to do.
- Scope: Python SDK pages only (de/es/pt-BR). The TypeScript SDK comments are already localized; other SDK pages not audited here.

## Verification
- `npm run typecheck` passes
- 0 residual English comments across the 3 files; diff is comment-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)