### PR TITLE
seo: point footer Status link at canonical URL (fix 310 temp redirects)

### DIFF
--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -50,7 +50,7 @@ const footerContent = (
     <nav className="sa-footer__links" aria-label="Footer">
       <a href="https://sharpapi.io">Home</a>
       <a href="https://sharpapi.io/pricing">Pricing</a>
-      <a href="https://status.sharpapi.io/en/" target="_blank" rel="noopener noreferrer">Status</a>
+      <a href="https://status.sharpapi.io/" target="_blank" rel="noopener noreferrer">Status</a>
       <a href="https://github.com/Sharp-API/SharpAPI-Documentation" target="_blank" rel="noopener noreferrer">GitHub</a>
     </nav>
   </div>


### PR DESCRIPTION
Fixes the **310 "URLs with a temporary redirect"** warning in the Semrush audit (campaign 29018595, new on the Jun 7 crawl).

## Root cause
The shared footer **Status** link targets `https://status.sharpapi.io/en/`, which BetterStack **302-redirects** to `https://status.sharpapi.io/`. Since the footer renders on every docs page, Semrush flagged all 310 crawled pages as linking through a temporary redirect — dropping Site Health 100% -> 99% and Healthy pages 303 -> 6.

The docs pages themselves are fine (200); only this one outbound footer link hops through a 302.

## Fix
```diff
- <a href="https://status.sharpapi.io/en/" ...>Status</a>
+ <a href="https://status.sharpapi.io/" ...>Status</a>
```
`https://status.sharpapi.io/` returns 200 directly. One layout edit clears the hop on all 310 pages (same shared-component pattern as the logo fix in #252).

## Verification
- `npm run typecheck` passes
- Confirmed: `/en/` -> 302 -> `/` (200); the other footer/nav links (sharpapi.io, /pricing, GitHub) are already clean 200s

🤖 Generated with [Claude Code](https://claude.com/claude-code)