### PR TITLE
docs(historical-clv): rewrite to the live ClickHouse response shape (E2+E4, ×4 locales)

### DIFF
--- a/content/de/api-reference/historical-clv.mdx
+++ b/content/de/api-reference/historical-clv.mdx
@@ -1,55 +1,60 @@
 ---
-description: "GET /api/v1/historical/clv — Closing Line Value-Analyse über Sportsbooks hinweg. Vergleichen Sie Ihre Schlusspreise mit der Pinnacle No-Vig-Wahrscheinlichkeit, um Ihren Edge zu messen. Sharp-Tier erforderlich."
+description: "GET /api/v1/historical/clv — Closing Line Value-Analyse der bewerteten +EV-Vorhersagen von SharpAPI, gruppiert nach Sportsbook, Sportart, Liga, Markt, Tag oder Sharp-Referenz (devig_book). Enterprise-Tier."
 ---
 
 import { Callout, Tabs } from 'nextra/components'
 
 # Closing Line Value (CLV)
 
-Analysieren Sie, wie gut die Schlussquoten eines Sportsbooks im Vergleich zur devigged (No-Vig) Wahrscheinlichkeit von Pinnacle abschneiden. Ein positiver CLV bedeutet, dass der Buchmacher lockerer geschlossen hat als Pinnacle — ein historischer Indikator für einen Edge.
+Aggregierte Closing-Line-Value-Statistiken für die bewerteten +EV-Vorhersagen von SharpAPI. Für jede +EV-Gelegenheit, die die Engine markiert, erfasst das System später die Schlusslinie der Sharp-Referenz und bewertet den Pick dagegen — dieser Endpoint liefert diese Bewertungen, aggregiert entlang der von Ihnen gewählten Dimension (`group_by`), zusammen mit realisierten Gewinn-/Verlust-Ergebnissen, sofern das Spielergebnis bekannt ist.
 
 ```
 GET /api/v1/historical/clv
 ```
 
 <Callout type="warning">
-**Sharp-Tier oder höher erforderlich.** Pro- und niedrigere Tiers erhalten einen `403 tier_restricted`-Fehler. Dieser Endpoint ist durch das `closing_lines`-Feature gesperrt.
+**Enterprise-Tier erforderlich.** Die `/api/v1/historical/*`-Aggregat-Endpoints sind durch das `history`-Feature gesperrt. Niedrigere Tiers erhalten `403 tier_restricted`. Wenn Sie **Pro oder Sharp** nutzen und Schlusslinien-Daten benötigen, verwenden Sie [Schlussquoten](/de/api-reference/odds-closing/) — rohe Schlusspreise pro Event, verfügbar in Ihrem Tier.
 </Callout>
 
-<Callout type="info">
-**Phase 1 Datenfenster:** Schlusslinien werden in Echtzeit erfasst, sobald Spiele live gehen. Der Valkey-Speicher behält die Daten **30 Tage** lang. Historische Daten, die älter als 30 Tage sind, sind noch nicht verfügbar.
-</Callout>
+## Wie der CLV berechnet wird
 
-## Wie Schlusslinien erfasst werden
-
-Wenn ein Spiel vom Pre-Match- in den Live-Status übergeht, erfasst der Server die letzten Pre-Match-Quoten jedes Buchmachers als Schlusslinie für dieses Event. Der Schlusspreis wird mit der **Power-Methode** devigged (dieselbe wie bei der EV-Berechnung), um eine No-Vig-Wahrscheinlichkeit pro Auswahl zu erzeugen.
-
-Der CLV wird dann wie folgt berechnet:
+Wenn ein Event vom Pre-Match- in den Live-Status übergeht, erfasst die Plattform den letzten Pre-Match-Preis jedes Buchmachers als Schlusslinie für dieses Event. Der Schlusspreis der **Sharp-Referenz** (`devig_book` — typischerweise Pinnacle) wird mit der Power-Methode zu einer No-Vig-Schlusswahrscheinlichkeit devigged, und jede bewertete Vorhersage wird wie folgt bewertet:
 
 ```
-CLV% = (pin_no_vig_prob - book_no_vig_prob) / book_no_vig_prob × 100
+CLV% = (closing_no_vig_prob × entry_decimal_odds − 1) × 100
 ```
 
-Wobei `pin_no_vig_prob` die devigged Wahrscheinlichkeit von Pinnacle (die Sharp-Referenz) und `book_no_vig_prob` die devigged Wahrscheinlichkeit des Soft-Buchmachers ist. Ein positiver CLV% bedeutet, dass der Soft-Buchmacher zu einem Preis geschlossen hat, der günstiger ist als die faire Pinnacle-Linie.
+Dabei ist `entry_decimal_odds` der Preis zu dem Zeitpunkt, an dem SharpAPI die Gelegenheit markiert hat. **Ein positiver CLV bedeutet, dass der markierte Preis die Schlusslinie geschlagen hat** — Sie hätten zu besseren Quoten wetten können, als der finale faire Marktwert implizierte.
 
-## Authentifizierung
-
-API key erforderlich. **Sharp-Tier oder höher erforderlich** (`closing_lines`-Feature).
+Die Daten stammen aus dem historischen ClickHouse-Speicher. Aggregate werden über **logische Vorhersagen** berechnet — wiederholte Preis-Snapshots desselben Picks (gleiches Event, gleicher Markt, gleiche Auswahl, gleicher Buchmacher, gleiche Linie) werden vor dem Zählen zu einer Zeile zusammengefasst, sodass ein Pick, der zu mehreren Preisen erneut beobachtet wurde, nicht mehrfach gezählt wird.
 
 ## Query-Parameter
 
 | Parameter | Typ | Standard | Beschreibung |
 |-----------|------|---------|-------------|
-| `from` | string | vor 7 Tagen | Startdatum (`YYYY-MM-DD` oder ISO 8601). Auf 30-Tage-Fenster begrenzt. |
+| `from` | string | vor 7 Tagen | Startdatum (`YYYY-MM-DD` oder ISO 8601). Wird auf das Verlaufsfenster Ihres Tiers begrenzt. |
 | `to` | string | heute | Enddatum (`YYYY-MM-DD` oder ISO 8601). |
-| `group_by` | string | `sportsbook` | Aggregationsdimension. Eine von: `sportsbook`, `sport`, `league`, `market`, `day`. |
-| `sport` | string | alle | Filter nach Sportart(en), kommagetrennt (z. B. `basketball,football`). |
-| `league` | string | alle | Filter nach Liga(en), kommagetrennt (z. B. `nba,nfl`). |
+| `group_by` | string | `sportsbook` | Aggregationsdimension. Eine von: `sportsbook`, `sport`, `league`, `market`, `day`, `devig_book`. |
+| `sport` | string | alle | Filter nach Sportart(en), kommagetrennt (z. B. `basketball,baseball`). |
+| `league` | string | alle | Filter nach Liga(en), kommagetrennt (z. B. `nba,mlb`). |
 | `sportsbook` | string | alle | Filter nach Sportsbook(s), kommagetrennt. |
+| `devig_book` | string | alle | Filter nach der Sharp-Referenz, gegen die der Pick bepreist wurde (z. B. `pinnacle`). |
 
-### Datumsfenster
+### Verlaufsfenster nach Tier
 
-Das Sharp-Tier erlaubt bis zu **30 Tage** Verlauf (das aktuelle Speicherfenster für Schlusslinien-Daten). Anfragen für Daten außerhalb dieses Fensters werden stillschweigend auf das früheste verfügbare Datum begrenzt.
+Datumsbereiche werden auf das Rückblickfenster Ihres Tiers begrenzt (ersichtlich in `meta.tier_window_days`):
+
+| Tier | Fenster |
+|------|--------|
+| Free | 7 Tage |
+| Hobby | 30 Tage |
+| Pro | 90 Tage |
+| Sharp | 365 Tage |
+| Enterprise | Unbegrenzt |
+
+<Callout type="info">
+**Filtern Sie nach `devig_book=pinnacle` für das aussagekräftige Signal.** Die Validität des CLV wird von der Sharp-Referenz dominiert, gegen die der Pick bepreist wurde. Pinnacle-referenzierter CLV ist die prädiktive Serie; Picks, die gegen Fallback-Referenzen (z. B. `bookmaker`) bepreist wurden, weisen strukturell negativen CLV auf und sollten nicht als Edge gelesen werden. Gruppieren Sie nach `devig_book`, um die Aufteilung zu sehen.
+</Callout>
 
 ## Beispielanfragen
 
@@ -57,32 +62,39 @@ Das Sharp-Tier erlaubt bis zu **30 Tage** Verlauf (das aktuelle Speicherfenster 
   <Tabs.Tab>
 ```bash
 # CLV nach Sportsbook für die letzten 7 Tage
-curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?from=2026-04-10&to=2026-04-17&group_by=sportsbook" \
+curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?group_by=sportsbook" \
   -H "X-API-Key: YOUR_API_KEY"
 
-# CLV gruppiert nach Sportart, nur NBA
-curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?league=nba&group_by=sport" \
+# Nur Pinnacle-referenzierter CLV, gruppiert nach Sportart
+curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?devig_book=pinnacle&group_by=sport" \
   -H "X-API-Key: YOUR_API_KEY"
 
-# CLV gruppiert nach Tag für DraftKings
-curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?sportsbook=draftkings&group_by=day" \
+# Tagesweiser CLV für DraftKings-Picks über einen Datumsbereich
+curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?sportsbook=draftkings&group_by=day&from=2026-06-01&to=2026-06-08" \
   -H "X-API-Key: YOUR_API_KEY"
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```javascript
 const params = new URLSearchParams({
-  from: '2026-04-10',
-  to: '2026-04-17',
+  devig_book: 'pinnacle',
   group_by: 'sportsbook',
 });
 const response = await fetch(
   `https://api.sharpapi.io/api/v1/historical/clv?${params}`,
   { headers: { 'X-API-Key': 'YOUR_API_KEY' } }
 );
-const { data, meta } = await response.json();
+const { data } = await response.json();
 for (const group of data.groups) {
-  console.log(`${group.group_key}: avg CLV ${group.avg_clv_percent.toFixed(2)}% (${group.samples} samples)`);
+  // avg_clv_percent, avg_ev_percent und win_rate sind null, wenn eine Gruppe
+  // keine bewerteten / keine abgerechneten Zeilen hat — vor dem Formatieren absichern.
+  const clv = group.avg_clv_percent !== null
+    ? `${group.avg_clv_percent.toFixed(2)}%`
+    : 'n/a';
+  const wr = group.win_rate !== null
+    ? `${(group.win_rate * 100).toFixed(1)}% over ${group.wins + group.losses} settled`
+    : 'no settled bets';
+  console.log(`${group.group_key}: avg CLV ${clv} (${group.total_graded} graded), win rate ${wr}`);
 }
 ```
   </Tabs.Tab>
@@ -92,20 +104,24 @@ import requests
 
 response = requests.get(
     'https://api.sharpapi.io/api/v1/historical/clv',
-    params={
-        'from': '2026-04-10',
-        'to': '2026-04-17',
-        'group_by': 'sportsbook',
-    },
-    headers={'X-API-Key': 'YOUR_API_KEY'}
+    params={'devig_book': 'pinnacle', 'group_by': 'sportsbook'},
+    headers={'X-API-Key': 'YOUR_API_KEY'},
 )
-data = response.json()
-for group in data['data']['groups']:
-    print(
-        f"{group['group_key']}: "
-        f"avg CLV {group['avg_clv_percent']:.2f}% "
-        f"({group['samples']} samples)"
+payload = response.json()
+for group in payload['data']['groups']:
+    # avg_clv_percent / avg_ev_percent / win_rate sind None, wenn eine Gruppe
+    # keine bewerteten / keine abgerechneten Zeilen hat — vor dem Formatieren absichern.
+    clv = (
+        f"{group['avg_clv_percent']:.2f}%"
+        if group['avg_clv_percent'] is not None else 'n/a'
     )
+    settled = group['wins'] + group['losses']
+    wr = (
+        f"{group['win_rate'] * 100:.1f}% over {settled} settled"
+        if group['win_rate'] is not None else 'no settled bets'
+    )
+    print(f"{group['group_key']}: avg CLV {clv} "
+          f"({group['total_graded']} graded), win rate {wr}")
 ```
   </Tabs.Tab>
 </Tabs>
@@ -118,74 +134,54 @@ for group in data['data']['groups']:
 {
   "success": true,
   "data": {
+    "date_range": {
+      "from": "2026-06-03T14:12:30.437",
+      "to": "2026-06-10T14:12:30.437"
+    },
     "group_by": "sportsbook",
     "groups": [
       {
-        "group_key": "draftkings",
-        "samples": 312,
-        "avg_clv_percent": 1.42,
-        "avg_abs_clv_percent": 2.18,
-        "distinct_books": 1,
-        "distinct_sports": 4
+        "group_key": "novig",
+        "total_graded": 1294,
+        "wins": 262,
+        "losses": 200,
+        "win_rate": 0.5670995670995671,
+        "avg_clv_percent": 0.673342797764432,
+        "avg_ev_percent": 1.613983921390446,
+        "total_predictions": 1555
       },
       {
-        "group_key": "fanduel",
-        "samples": 289,
-        "avg_clv_percent": 0.87,
-        "avg_abs_clv_percent": 1.95,
-        "distinct_books": 1,
-        "distinct_sports": 4
-      },
-      {
-        "group_key": "betmgm",
-        "samples": 201,
-        "avg_clv_percent": -0.21,
-        "avg_abs_clv_percent": 1.74,
-        "distinct_books": 1,
-        "distinct_sports": 3
+        "group_key": "prophetx",
+        "total_graded": 964,
+        "wins": 191,
+        "losses": 214,
+        "win_rate": 0.47160493827160493,
+        "avg_clv_percent": 0.07641414602522267,
+        "avg_ev_percent": 1.4343012769214647,
+        "total_predictions": 1331
       }
-    ],
-    "date_range": {
-      "from": "2026-04-10T00:00:00.000",
-      "to": "2026-04-17T00:00:00.000"
-    },
-    "total_events": 58,
-    "comparable_events": 51,
-    "sharp_reference": "pinnacle"
+    ]
   },
   "meta": {
-    "source": "valkey:closing_line",
-    "tier_window_days": 30,
-    "phase": "1",
     "filters": {
-      "sport": null,
+      "devig_book": null,
+      "group_by": "sportsbook",
       "league": null,
-      "sportsbook": null,
-      "group_by": "sportsbook"
+      "sport": null,
+      "sportsbook": null
     },
-    "updated_at": "2026-04-17T20:00:00.000000000Z"
+    "source": "clickhouse",
+    "tier_window_days": "unlimited",
+    "updated_at": "2026-06-10T14:12:58.75061216Z"
   }
 }
 ```
 
-**Leeres Ergebnis (noch keine Schlusslinien-Daten):**
+Ein leeres `groups`-Array ist eine gültige Antwort, wenn für die angefragten Filter und den Datumsbereich keine bewerteten Vorhersagen existieren — kein Fehler.
 
-```json
-{
-  "success": true,
-  "data": {
-    "group_by": "sportsbook",
-    "groups": [],
-    "date_range": { "from": "...", "to": "..." },
-    "total_events": 0,
-    "comparable_events": 0,
-    "sharp_reference": "pinnacle"
-  },
-  "meta": { "source": "valkey:closing_line", "phase": "1", ... }
-}
-```
-
-Ein leeres `groups`-Array ist eine gültige Antwort, wenn für den angefragten Datumsbereich keine Schlusslinien-Daten erfasst wurden — kein Fehler.
+<Callout type="warning">
+**Drei verschiedene Zählungen — vermischen Sie die Nenner nicht.** `total_predictions` zählt jeden verfolgten Pick (einschließlich nie bewerteter). `total_graded` zählt Picks mit einer **CLV-Bewertung** (eine Schlusslinie wurde erfasst und verglichen). `wins + losses` zählt die typischerweise kleinere Teilmenge, deren **Spielergebnis** ebenfalls abgerechnet ist — und `win_rate` wird nur über diese Teilmenge berechnet. Eine Gruppe kann legitim `total_graded: 1294` neben `wins + losses: 462` aufweisen. `win_rate` ist `null`, wenn eine Gruppe keine abgerechneten Wetten hat.
+</Callout>
 
 ### Fehlerantworten
 
@@ -194,9 +190,10 @@ Ein leeres `groups`-Array ist eine gültige Antwort, wenn für den angefragten D
 {
   "error": {
     "code": "tier_restricted",
-    "message": "The 'closing_lines' feature requires Sharp or higher.",
-    "required_tier": "sharp",
-    "docs": "https://docs.sharpapi.io/en/pricing"
+    "message": "This endpoint requires Enterprise tier or higher",
+    "docs": "https://sharpapi.io/pricing",
+    "tier": "pro",
+    "required_tier": "enterprise"
   }
 }
 ```
@@ -206,7 +203,7 @@ Ein leeres `groups`-Array ist eine gültige Antwort, wenn für den angefragten D
 {
   "error": {
     "code": "validation_error",
-    "message": "Invalid group_by. Must be one of: day, league, market, sport, sportsbook"
+    "message": "Invalid group_by. Must be one of: day, devig_book, league, market, sport, sportsbook"
   }
 }
 ```
@@ -217,31 +214,30 @@ Ein leeres `groups`-Array ist eine gültige Antwort, wenn für den angefragten D
 
 | Feld | Typ | Beschreibung |
 |-------|------|-------------|
-| `group_by` | string | Die für die Aggregation verwendete Dimension |
-| `groups` | array | Array von Gruppenzeilen, sortiert nach `samples` absteigend |
 | `date_range` | object | Tatsächlich verwendete `from`/`to`-Werte nach Tier-Begrenzung |
-| `total_events` | integer | Gesamtzahl der im Datumsbereich gefundenen Events (vor Pinnacle-Filter) |
-| `comparable_events` | integer | Events mit verfügbarer Pinnacle-Schlusslinie zum Vergleich |
-| `sharp_reference` | string | Als Fair-Odds-Referenz verwendeter Sharp-Buchmacher (`"pinnacle"`) |
+| `group_by` | string | Die für die Aggregation verwendete Dimension |
+| `groups` | array | Array von Gruppenzeilen |
 
 ### Felder der Gruppenzeile
 
 | Feld | Typ | Beschreibung |
 |-------|------|-------------|
-| `group_key` | string | Der Gruppenbezeichner (Sportsbook-Name, Sportart, Liga, Markttyp oder YYYY-MM-DD-Datum) |
-| `samples` | integer | Anzahl der Schlusslinien-Vergleiche in dieser Gruppe |
-| `avg_clv_percent` | number | Durchschnittlicher CLV% über alle Samples. Positiv = Buchmacher hat lockerer als Pinnacle geschlossen. |
-| `avg_abs_clv_percent` | number | Durchschnittlicher absoluter CLV% (richtungsunabhängiges Maß für Markteffizienz) |
-| `distinct_books` | integer | Anzahl der unterschiedlichen Buchmacher in dieser Gruppe |
-| `distinct_sports` | integer | Anzahl der unterschiedlichen Sportarten in dieser Gruppe |
+| `group_key` | string | Der Gruppenbezeichner (Sportsbook-Name, Sportart, Liga, Markttyp, `YYYY-MM-DD`-Datum oder Devig-Book) |
+| `total_graded` | integer | Logische Vorhersagen mit einer CLV-Bewertung (Schlusslinie erfasst und verglichen) |
+| `wins` | integer | Bewertete Vorhersagen, deren Spielergebnis als Gewinn abgerechnet wurde |
+| `losses` | integer | Bewertete Vorhersagen, deren Spielergebnis als Verlust abgerechnet wurde |
+| `win_rate` | number \| null | `wins / (wins + losses)`. Wird nur über die abgerechnete Teilmenge berechnet; `null`, wenn keine abgerechneten Wetten in der Gruppe existieren |
+| `avg_clv_percent` | number \| null | Durchschnittlicher CLV% über die bewerteten Vorhersagen. Positiv = markierte Preise haben die Schlusslinie im Durchschnitt geschlagen. `null`, wenn nicht berechenbar |
+| `avg_ev_percent` | number \| null | Durchschnittlicher erwarteter Wert in % zum Erkennungszeitpunkt für die Vorhersagen der Gruppe. `null`, wenn nicht berechenbar |
+| `total_predictions` | integer | Alle verfolgten Vorhersagen in der Gruppe, einschließlich (noch) nicht bewerteter |
 
 ### `meta`-Objekt
 
 | Feld | Typ | Beschreibung |
 |-------|------|-------------|
-| `source` | string | Immer `"valkey:closing_line"` (Phase-1-Backend) |
-| `tier_window_days` | integer | Maximaler Rückblick in Tagen für Ihr Tier (Sharp = 30) |
-| `phase` | string | `"1"` — Echtzeit-Erfassung bei Live-Übergängen. ClickHouse-Backfill für Phase 2 geplant. |
+| `filters` | object | Echo der angewendeten Filter (`sport`, `league`, `sportsbook`, `devig_book`, `group_by`); `null` für nicht verwendete Filter |
+| `source` | string | `"clickhouse"` — der historische Analytics-Speicher |
+| `tier_window_days` | integer \| string | Maximaler Rückblick für Ihr Tier (z. B. `90`) oder `"unlimited"` |
 | `updated_at` | string | ISO 8601 Antwort-Zeitstempel |
 
 ---
@@ -250,15 +246,23 @@ Ein leeres `groups`-Array ist eine gültige Antwort, wenn für den angefragten D
 
 | CLV% | Interpretation |
 |------|----------------|
-| **> +2%** | Buchmacher hat durchgängig deutlich lockerer als Sharp-Linien geschlossen — hoher Wert erfasst |
-| **+0,5% bis +2%** | Buchmacher hat leicht locker geschlossen — typisch für Freizeit-Buchmacher |
-| **-0,5% bis +0,5%** | Marktnaher Schluss — effizient oder gemischt |
-| **< -0,5%** | Buchmacher hat sich zum Schluss verengt — kann auf Steam Chasing oder Sharp-Side-Action hinweisen |
+| **> +2%** | Markierte Preise haben die Schlusslinie durchgängig deutlich geschlagen — hoher erfasster Wert |
+| **+0,5% bis +2%** | Preise haben die Schlusslinie leicht geschlagen — typisch für Soft Books gegenüber einer Sharp-Referenz |
+| **-0,5% bis +0,5%** | Marktnah — effiziente Preisbildung oder gemischte Ergebnisse |
+| **< -0,5%** | Preise haben sich zum Schluss hin verengt — spätes Steam oder Sharp-Side-Action |
 
-Ein positiver durchschnittlicher CLV bei Ihren Wetten ist der stärkste Indikator dafür, dass Sie auf ineffiziente Preise setzen. Über eine große Stichprobe hinweg sagt ein positiver CLV einen positiven ROI stark voraus.
+<Callout type="info">
+**CLV ist nicht ROI — lesen Sie ihn mit den richtigen Vorbehalten.**
+
+- **Die Markteffizienz variiert.** In den schärfsten, liquidesten Märkten (zum Beispiel NBA-Spreads und -Totals sowie Player Props der großen Ligen) führt das Schlagen der Schlusslinie **nicht** zuverlässig zu realisiertem Gewinn — Closing-Line-Beats spiegeln dort oft Rauschen in einem effizienten Markt wider statt Edge. In weicheren Märkten bleibt positiver CLV der beste Frühindikator für langfristige Profitabilität.
+- **Nutzen Sie `win_rate` zusammen mit `avg_clv_percent`.** Der Endpoint liefert realisierte Ergebnisse genau aus diesem Grund: Eine Gruppe mit positivem CLV, aber einer abgerechneten Bilanz unterhalb des Break-even über eine große Stichprobe sagt Ihnen, dass der CLV dort nicht konvertiert.
+- **Achten Sie auf die Stichprobengröße.** Gruppen mit kleinem `total_graded` oder wenigen abgerechneten Wetten (`wins + losses`) sind Rauschen — vergleichen Sie Gruppen nur bei aussagekräftigem Volumen.
+- **Die Sharp-Referenz ist entscheidend.** Nur Sharp-referenzierter CLV (Filter `devig_book=pinnacle`) trägt diese Bedeutung; Fallback-referenzierte Zeilen nicht.
+</Callout>
 
 ## Verwandte Endpoints
 
-- [Schlussquoten nach Datum](/de/api-reference/historical-odds-closing/) — Rohdaten der Schlusspreise pro Event für ein bestimmtes Datum
+- [Schlussquoten](/de/api-reference/odds-closing/) — Rohe Schlusspreise pro Event (ab Pro-Tier)
+- [Schlussquoten nach Datum](/de/api-reference/historical-odds-closing/) — Historische Schlusspreise pro Event für ein bestimmtes Datum
 - [+EV-Gelegenheiten](/de/api-reference/opportunities-ev/) — Echtzeit-Wetten mit positivem erwarteten Wert
 - [Quoten-Snapshot](/de/api-reference/odds/) — Aktuelle Pre-Match- und Live-Quoten

--- a/content/en/api-reference/historical-clv.mdx
+++ b/content/en/api-reference/historical-clv.mdx
@@ -1,55 +1,60 @@
 ---
-description: "GET /api/v1/historical/clv — Closing Line Value analysis across sportsbooks. Compare your closing prices against Pinnacle's no-vig probability to measure edge. Sharp tier required."
+description: "GET /api/v1/historical/clv — Closing Line Value analysis of SharpAPI's graded +EV predictions, grouped by sportsbook, sport, league, market, day, or sharp reference (devig_book). Enterprise tier."
 ---
 
 import { Callout, Tabs } from 'nextra/components'
 
 # Closing Line Value (CLV)
 
-Analyze how well a sportsbook's closing odds compare to Pinnacle's devigged (no-vig) probability. Positive CLV means the book closed looser than Pinnacle — a historical proxy for edge.
+Aggregate Closing Line Value statistics for SharpAPI's graded +EV predictions. For every +EV opportunity the engine flags, the system later captures the sharp reference's closing line and grades the pick against it — this endpoint serves those grades, aggregated along the dimension you choose (`group_by`), together with realized win/loss outcomes where the game result is known.
 
 ```
 GET /api/v1/historical/clv
 ```
 
 <Callout type="warning">
-**Sharp tier or higher required.** Pro and lower tiers receive a `403 tier_restricted` error. This endpoint is gated by the `closing_lines` feature.
+**Enterprise tier required.** The `/api/v1/historical/*` aggregate endpoints are gated by the `history` feature. Lower tiers receive `403 tier_restricted`. If you're on **Pro or Sharp** and want closing-line data, use [Closing Odds](/en/api-reference/odds-closing/) — per-event raw closing prices, available on your tier.
 </Callout>
 
-<Callout type="info">
-**Phase 1 data window:** Closing lines are captured in real-time as games go live. The Valkey store retains data for **30 days**. Historical data beyond 30 days is not yet available.
-</Callout>
+## How CLV is computed
 
-## How Closing Lines Are Captured
-
-When a game transitions from pre-match to live, the server captures each book's last pre-match odds as that event's closing line. The closing price is devigged using the **Power method** (same as EV calculation) to produce a no-vig probability per selection.
-
-CLV is then computed as:
+When an event transitions from pre-match to live, the platform captures each book's last pre-match price as that event's closing line. The closing price of the **sharp reference** (`devig_book` — typically Pinnacle) is devigged with the Power method to a no-vig closing probability, and each graded prediction is scored as:
 
 ```
-CLV% = (pin_no_vig_prob - book_no_vig_prob) / book_no_vig_prob × 100
+CLV% = (closing_no_vig_prob × entry_decimal_odds − 1) × 100
 ```
 
-Where `pin_no_vig_prob` is Pinnacle's devigged probability (the sharp reference) and `book_no_vig_prob` is the soft book's devigged probability. A positive CLV% means the soft book closed at a price more favorable than the Pinnacle fair line.
+where `entry_decimal_odds` is the price at the moment SharpAPI flagged the opportunity. **Positive CLV means the flagged price beat the close** — you could have bet at better odds than the market's final fair value implied.
 
-## Authentication
-
-Requires API key. **Sharp tier or higher required** (`closing_lines` feature).
+Data is served from the historical ClickHouse store. Aggregates are computed over **logical predictions** — repeated price snapshots of the same pick (same event, market, selection, book, line) are collapsed into one row before counting, so a pick that was re-observed at several prices is not counted multiple times.
 
 ## Query Parameters
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `from` | string | 7 days ago | Start date (`YYYY-MM-DD` or ISO 8601). Clamped to 30-day window. |
+| `from` | string | 7 days ago | Start date (`YYYY-MM-DD` or ISO 8601). Clamped to your tier's history window. |
 | `to` | string | today | End date (`YYYY-MM-DD` or ISO 8601). |
-| `group_by` | string | `sportsbook` | Aggregation dimension. One of: `sportsbook`, `sport`, `league`, `market`, `day`. |
-| `sport` | string | all | Filter by sport(s), comma-separated (e.g. `basketball,football`). |
-| `league` | string | all | Filter by league(s), comma-separated (e.g. `nba,nfl`). |
+| `group_by` | string | `sportsbook` | Aggregation dimension. One of: `sportsbook`, `sport`, `league`, `market`, `day`, `devig_book`. |
+| `sport` | string | all | Filter by sport(s), comma-separated (e.g. `basketball,baseball`). |
+| `league` | string | all | Filter by league(s), comma-separated (e.g. `nba,mlb`). |
 | `sportsbook` | string | all | Filter by sportsbook(s), comma-separated. |
+| `devig_book` | string | all | Filter by the sharp reference the pick was priced against (e.g. `pinnacle`). |
 
-### Date Window
+### History window by tier
 
-Sharp tier allows up to **30 days** of history (the current retention window for closing line data). Requesting dates outside this window is clamped silently to the earliest available date.
+Date ranges are clamped to your tier's lookback window (reflected in `meta.tier_window_days`):
+
+| Tier | Window |
+|------|--------|
+| Free | 7 days |
+| Hobby | 30 days |
+| Pro | 90 days |
+| Sharp | 365 days |
+| Enterprise | Unlimited |
+
+<Callout type="info">
+**Filter by `devig_book=pinnacle` for the meaningful signal.** CLV validity is dominated by the sharp reference the pick was priced against. Pinnacle-referenced CLV is the predictive series; picks priced against fallback references (e.g. `bookmaker`) carry structurally negative CLV and should not be read as edge. Group by `devig_book` to see the split.
+</Callout>
 
 ## Example Requests
 
@@ -57,32 +62,39 @@ Sharp tier allows up to **30 days** of history (the current retention window for
   <Tabs.Tab>
 ```bash
 # CLV by sportsbook for the past 7 days
-curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?from=2026-04-10&to=2026-04-17&group_by=sportsbook" \
+curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?group_by=sportsbook" \
   -H "X-API-Key: YOUR_API_KEY"
 
-# CLV grouped by sport, NBA only
-curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?league=nba&group_by=sport" \
+# Pinnacle-referenced CLV only, grouped by sport
+curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?devig_book=pinnacle&group_by=sport" \
   -H "X-API-Key: YOUR_API_KEY"
 
-# CLV grouped by day for DraftKings
-curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?sportsbook=draftkings&group_by=day" \
+# Day-by-day CLV for DraftKings picks over a date range
+curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?sportsbook=draftkings&group_by=day&from=2026-06-01&to=2026-06-08" \
   -H "X-API-Key: YOUR_API_KEY"
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```javascript
 const params = new URLSearchParams({
-  from: '2026-04-10',
-  to: '2026-04-17',
+  devig_book: 'pinnacle',
   group_by: 'sportsbook',
 });
 const response = await fetch(
   `https://api.sharpapi.io/api/v1/historical/clv?${params}`,
   { headers: { 'X-API-Key': 'YOUR_API_KEY' } }
 );
-const { data, meta } = await response.json();
+const { data } = await response.json();
 for (const group of data.groups) {
-  console.log(`${group.group_key}: avg CLV ${group.avg_clv_percent.toFixed(2)}% (${group.samples} samples)`);
+  // avg_clv_percent, avg_ev_percent, and win_rate are null when a group
+  // has no graded / no settled rows — guard before formatting.
+  const clv = group.avg_clv_percent !== null
+    ? `${group.avg_clv_percent.toFixed(2)}%`
+    : 'n/a';
+  const wr = group.win_rate !== null
+    ? `${(group.win_rate * 100).toFixed(1)}% over ${group.wins + group.losses} settled`
+    : 'no settled bets';
+  console.log(`${group.group_key}: avg CLV ${clv} (${group.total_graded} graded), win rate ${wr}`);
 }
 ```
   </Tabs.Tab>
@@ -92,20 +104,24 @@ import requests
 
 response = requests.get(
     'https://api.sharpapi.io/api/v1/historical/clv',
-    params={
-        'from': '2026-04-10',
-        'to': '2026-04-17',
-        'group_by': 'sportsbook',
-    },
-    headers={'X-API-Key': 'YOUR_API_KEY'}
+    params={'devig_book': 'pinnacle', 'group_by': 'sportsbook'},
+    headers={'X-API-Key': 'YOUR_API_KEY'},
 )
-data = response.json()
-for group in data['data']['groups']:
-    print(
-        f"{group['group_key']}: "
-        f"avg CLV {group['avg_clv_percent']:.2f}% "
-        f"({group['samples']} samples)"
+payload = response.json()
+for group in payload['data']['groups']:
+    # avg_clv_percent / avg_ev_percent / win_rate are None when a group has
+    # no graded / no settled rows — guard before formatting.
+    clv = (
+        f"{group['avg_clv_percent']:.2f}%"
+        if group['avg_clv_percent'] is not None else 'n/a'
     )
+    settled = group['wins'] + group['losses']
+    wr = (
+        f"{group['win_rate'] * 100:.1f}% over {settled} settled"
+        if group['win_rate'] is not None else 'no settled bets'
+    )
+    print(f"{group['group_key']}: avg CLV {clv} "
+          f"({group['total_graded']} graded), win rate {wr}")
 ```
   </Tabs.Tab>
 </Tabs>
@@ -118,74 +134,54 @@ for group in data['data']['groups']:
 {
   "success": true,
   "data": {
+    "date_range": {
+      "from": "2026-06-03T14:12:30.437",
+      "to": "2026-06-10T14:12:30.437"
+    },
     "group_by": "sportsbook",
     "groups": [
       {
-        "group_key": "draftkings",
-        "samples": 312,
-        "avg_clv_percent": 1.42,
-        "avg_abs_clv_percent": 2.18,
-        "distinct_books": 1,
-        "distinct_sports": 4
+        "group_key": "novig",
+        "total_graded": 1294,
+        "wins": 262,
+        "losses": 200,
+        "win_rate": 0.5670995670995671,
+        "avg_clv_percent": 0.673342797764432,
+        "avg_ev_percent": 1.613983921390446,
+        "total_predictions": 1555
       },
       {
-        "group_key": "fanduel",
-        "samples": 289,
-        "avg_clv_percent": 0.87,
-        "avg_abs_clv_percent": 1.95,
-        "distinct_books": 1,
-        "distinct_sports": 4
-      },
-      {
-        "group_key": "betmgm",
-        "samples": 201,
-        "avg_clv_percent": -0.21,
-        "avg_abs_clv_percent": 1.74,
-        "distinct_books": 1,
-        "distinct_sports": 3
+        "group_key": "prophetx",
+        "total_graded": 964,
+        "wins": 191,
+        "losses": 214,
+        "win_rate": 0.47160493827160493,
+        "avg_clv_percent": 0.07641414602522267,
+        "avg_ev_percent": 1.4343012769214647,
+        "total_predictions": 1331
       }
-    ],
-    "date_range": {
-      "from": "2026-04-10T00:00:00.000",
-      "to": "2026-04-17T00:00:00.000"
-    },
-    "total_events": 58,
-    "comparable_events": 51,
-    "sharp_reference": "pinnacle"
+    ]
   },
   "meta": {
-    "source": "valkey:closing_line",
-    "tier_window_days": 30,
-    "phase": "1",
     "filters": {
-      "sport": null,
+      "devig_book": null,
+      "group_by": "sportsbook",
       "league": null,
-      "sportsbook": null,
-      "group_by": "sportsbook"
+      "sport": null,
+      "sportsbook": null
     },
-    "updated_at": "2026-04-17T20:00:00.000000000Z"
+    "source": "clickhouse",
+    "tier_window_days": "unlimited",
+    "updated_at": "2026-06-10T14:12:58.75061216Z"
   }
 }
 ```
 
-**Empty result (no closing line data yet):**
+An empty `groups` array is a valid response when no graded predictions exist for the requested filters and date range — not an error.
 
-```json
-{
-  "success": true,
-  "data": {
-    "group_by": "sportsbook",
-    "groups": [],
-    "date_range": { "from": "...", "to": "..." },
-    "total_events": 0,
-    "comparable_events": 0,
-    "sharp_reference": "pinnacle"
-  },
-  "meta": { "source": "valkey:closing_line", "phase": "1", ... }
-}
-```
-
-An empty `groups` array is a valid response when no closing line data has been captured for the requested date range — not an error.
+<Callout type="warning">
+**Three different counts — don't mix denominators.** `total_predictions` counts every tracked pick (including ones never graded). `total_graded` counts picks with a **CLV grade** (a closing line was captured and compared). `wins + losses` counts the typically smaller subset whose **game outcome** is also settled — and `win_rate` is computed over that subset only. A group can legitimately show `total_graded: 1294` next to `wins + losses: 462`. `win_rate` is `null` when a group has no settled bets.
+</Callout>
 
 ### Error Responses
 
@@ -194,9 +190,10 @@ An empty `groups` array is a valid response when no closing line data has been c
 {
   "error": {
     "code": "tier_restricted",
-    "message": "The 'closing_lines' feature requires Sharp or higher.",
-    "required_tier": "sharp",
-    "docs": "https://docs.sharpapi.io/en/pricing"
+    "message": "This endpoint requires Enterprise tier or higher",
+    "docs": "https://sharpapi.io/pricing",
+    "tier": "pro",
+    "required_tier": "enterprise"
   }
 }
 ```
@@ -206,7 +203,7 @@ An empty `groups` array is a valid response when no closing line data has been c
 {
   "error": {
     "code": "validation_error",
-    "message": "Invalid group_by. Must be one of: day, league, market, sport, sportsbook"
+    "message": "Invalid group_by. Must be one of: day, devig_book, league, market, sport, sportsbook"
   }
 }
 ```
@@ -217,31 +214,30 @@ An empty `groups` array is a valid response when no closing line data has been c
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `group_by` | string | The dimension used for aggregation |
-| `groups` | array | Array of group rows, sorted by `samples` descending |
 | `date_range` | object | Actual `from`/`to` used after tier clamping |
-| `total_events` | integer | Total events found in the date range (before Pinnacle filter) |
-| `comparable_events` | integer | Events with a Pinnacle closing line available for comparison |
-| `sharp_reference` | string | Sharp book used as the fair-odds reference (`"pinnacle"`) |
+| `group_by` | string | The dimension used for aggregation |
+| `groups` | array | Array of group rows |
 
 ### Group row fields
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `group_key` | string | The group identifier (sportsbook name, sport, league, market type, or YYYY-MM-DD date) |
-| `samples` | integer | Number of closing line comparisons in this group |
-| `avg_clv_percent` | number | Average CLV% across all samples. Positive = book closed looser than Pinnacle. |
-| `avg_abs_clv_percent` | number | Average absolute CLV% (direction-agnostic market efficiency measure) |
-| `distinct_books` | integer | Number of distinct books in this group |
-| `distinct_sports` | integer | Number of distinct sports in this group |
+| `group_key` | string | The group identifier (sportsbook name, sport, league, market type, `YYYY-MM-DD` date, or devig book) |
+| `total_graded` | integer | Logical predictions with a CLV grade (closing line captured and compared) |
+| `wins` | integer | Graded predictions whose game outcome settled as a win |
+| `losses` | integer | Graded predictions whose game outcome settled as a loss |
+| `win_rate` | number \| null | `wins / (wins + losses)`. Computed over the settled subset only; `null` when no settled bets exist in the group |
+| `avg_clv_percent` | number \| null | Average CLV% across graded predictions. Positive = flagged prices beat the close on average. `null` when not computable |
+| `avg_ev_percent` | number \| null | Average expected value % at detection time for the group's predictions. `null` when not computable |
+| `total_predictions` | integer | All tracked predictions in the group, including ones not (yet) graded |
 
 ### `meta` object
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `source` | string | Always `"valkey:closing_line"` (Phase 1 backend) |
-| `tier_window_days` | integer | Maximum lookback days for your tier (Sharp = 30) |
-| `phase` | string | `"1"` — real-time capture from live transitions. ClickHouse backfill planned for Phase 2. |
+| `filters` | object | Echo of the applied filters (`sport`, `league`, `sportsbook`, `devig_book`, `group_by`); `null` for unused filters |
+| `source` | string | `"clickhouse"` — the historical analytics store |
+| `tier_window_days` | integer \| string | Maximum lookback for your tier (e.g. `90`), or `"unlimited"` |
 | `updated_at` | string | ISO 8601 response timestamp |
 
 ---
@@ -250,15 +246,23 @@ An empty `groups` array is a valid response when no closing line data has been c
 
 | CLV% | Interpretation |
 |------|----------------|
-| **> +2%** | Book consistently closed significantly looser than sharp lines — high value captured |
-| **+0.5% to +2%** | Book closed slightly loose — typical for recreational books |
-| **-0.5% to +0.5%** | Near-market close — efficient or mixed |
-| **< -0.5%** | Book tightened into close — may indicate steam chasing or sharp-side action |
+| **> +2%** | Flagged prices consistently beat the close by a wide margin — strong captured value |
+| **+0.5% to +2%** | Prices modestly beat the close — typical for soft books against a sharp reference |
+| **-0.5% to +0.5%** | Near-market — efficient pricing or mixed results |
+| **< -0.5%** | Prices tightened into the close — late steam or sharp-side action |
 
-A positive average CLV on your bets is the strongest indicator that you're betting into inefficient prices. Over a large sample, positive CLV strongly predicts positive ROI.
+<Callout type="info">
+**CLV is not ROI — read it with the right caveats.**
+
+- **Market efficiency varies.** In the sharpest, most liquid markets (for example NBA spreads and totals, and major-league player props), beating the close does **not** reliably convert into realized profit — closing-line beats there often reflect noise in an efficient market rather than edge. In softer markets, positive CLV remains the best leading indicator of long-run profitability.
+- **Use `win_rate` alongside `avg_clv_percent`.** The endpoint returns realized outcomes for exactly this reason: a group with positive CLV but a sub-breakeven settled record over a large sample is telling you the CLV there isn't converting.
+- **Mind the sample size.** Groups with small `total_graded` or few settled bets (`wins + losses`) are noise — compare groups only at meaningful volume.
+- **The sharp reference matters.** Only sharp-referenced CLV (filter `devig_book=pinnacle`) carries this meaning; fallback-referenced rows do not.
+</Callout>
 
 ## Related Endpoints
 
-- [Closing Odds by Date](/en/api-reference/historical-odds-closing/) — Per-event raw closing prices for a given date
+- [Closing Odds](/en/api-reference/odds-closing/) — Per-event raw closing prices (Pro tier and up)
+- [Closing Odds by Date](/en/api-reference/historical-odds-closing/) — Historical per-event closing prices for a given date
 - [+EV Opportunities](/en/api-reference/opportunities-ev/) — Real-time positive expected value bets
 - [Odds Snapshot](/en/api-reference/odds/) — Current pre-match and live odds

--- a/content/es/api-reference/historical-clv.mdx
+++ b/content/es/api-reference/historical-clv.mdx
@@ -1,55 +1,60 @@
 ---
-description: "GET /api/v1/historical/clv — Análisis del Valor de la Línea de Cierre (Closing Line Value) entre casas de apuestas. Compara tus precios de cierre con la probabilidad sin margen de Pinnacle para medir tu ventaja. Requiere nivel Sharp."
+description: "GET /api/v1/historical/clv — Análisis del Valor de la Línea de Cierre (Closing Line Value) de las predicciones +EV calificadas de SharpAPI, agrupado por casa de apuestas, deporte, liga, mercado, día o referencia sharp (devig_book). Nivel Enterprise."
 ---
 
 import { Callout, Tabs } from 'nextra/components'
 
 # Valor de la Línea de Cierre (CLV)
 
-Analiza cómo se comparan las cuotas de cierre de una casa de apuestas con la probabilidad sin margen (devigged) de Pinnacle. Un CLV positivo significa que la casa cerró con precios más laxos que Pinnacle — un indicador histórico de ventaja.
+Estadísticas agregadas de Valor de la Línea de Cierre para las predicciones +EV calificadas de SharpAPI. Para cada oportunidad +EV que el motor detecta, el sistema captura posteriormente la línea de cierre de la referencia sharp y califica la selección contra ella — este endpoint sirve esas calificaciones, agregadas según la dimensión que elijas (`group_by`), junto con los resultados realizados de victoria/derrota cuando se conoce el resultado del partido.
 
 ```
 GET /api/v1/historical/clv
 ```
 
 <Callout type="warning">
-**Se requiere nivel Sharp o superior.** Los niveles Pro e inferiores reciben un error `403 tier_restricted`. Este endpoint está restringido por la funcionalidad `closing_lines`.
+**Se requiere nivel Enterprise.** Los endpoints agregados `/api/v1/historical/*` están restringidos por la funcionalidad `history`. Los niveles inferiores reciben `403 tier_restricted`. Si estás en **Pro o Sharp** y quieres datos de líneas de cierre, usa [Cuotas de cierre](/es/api-reference/odds-closing/) — precios de cierre brutos por evento, disponibles en tu nivel.
 </Callout>
 
-<Callout type="info">
-**Ventana de datos de la Fase 1:** Las líneas de cierre se capturan en tiempo real cuando los partidos pasan a estar en directo. El almacén Valkey conserva los datos durante **30 días**. Los datos históricos anteriores a 30 días aún no están disponibles.
-</Callout>
+## Cómo se calcula el CLV
 
-## Cómo se capturan las líneas de cierre
-
-Cuando un partido pasa de pre-match a en directo, el servidor captura las últimas cuotas pre-match de cada casa como la línea de cierre de ese evento. El precio de cierre se devigea utilizando el **método Power** (el mismo que en el cálculo de EV) para producir una probabilidad sin margen por selección.
-
-El CLV se calcula entonces como:
+Cuando un evento pasa de pre-match a en directo, la plataforma captura el último precio pre-match de cada casa como la línea de cierre de ese evento. El precio de cierre de la **referencia sharp** (`devig_book` — normalmente Pinnacle) se devigea con el método Power para obtener una probabilidad de cierre sin margen (no-vig), y cada predicción calificada se puntúa como:
 
 ```
-CLV% = (pin_no_vig_prob - book_no_vig_prob) / book_no_vig_prob × 100
+CLV% = (closing_no_vig_prob × entry_decimal_odds − 1) × 100
 ```
 
-Donde `pin_no_vig_prob` es la probabilidad devigeada de Pinnacle (la referencia sharp) y `book_no_vig_prob` es la probabilidad devigeada de la casa soft. Un CLV% positivo significa que la casa soft cerró a un precio más favorable que la línea justa de Pinnacle.
+donde `entry_decimal_odds` es el precio en el momento en que SharpAPI detectó la oportunidad. **Un CLV positivo significa que el precio detectado batió al cierre** — podrías haber apostado a mejores cuotas que las que implicaba el valor justo final del mercado.
 
-## Autenticación
-
-Requiere API key. **Se requiere nivel Sharp o superior** (funcionalidad `closing_lines`).
+Los datos se sirven desde el almacén histórico ClickHouse. Los agregados se calculan sobre **predicciones lógicas** — los snapshots de precio repetidos de la misma selección (mismo evento, mercado, selección, casa, línea) se colapsan en una sola fila antes de contar, de modo que una selección re-observada a varios precios no se cuenta varias veces.
 
 ## Parámetros de consulta
 
 | Parámetro | Tipo | Por defecto | Descripción |
 |-----------|------|---------|-------------|
-| `from` | string | hace 7 días | Fecha de inicio (`YYYY-MM-DD` o ISO 8601). Limitada a una ventana de 30 días. |
+| `from` | string | hace 7 días | Fecha de inicio (`YYYY-MM-DD` o ISO 8601). Limitada a la ventana de histórico de tu nivel. |
 | `to` | string | hoy | Fecha de fin (`YYYY-MM-DD` o ISO 8601). |
-| `group_by` | string | `sportsbook` | Dimensión de agregación. Una de: `sportsbook`, `sport`, `league`, `market`, `day`. |
-| `sport` | string | todos | Filtrar por deporte(s), separados por comas (p. ej. `basketball,football`). |
-| `league` | string | todas | Filtrar por liga(s), separadas por comas (p. ej. `nba,nfl`). |
+| `group_by` | string | `sportsbook` | Dimensión de agregación. Una de: `sportsbook`, `sport`, `league`, `market`, `day`, `devig_book`. |
+| `sport` | string | todos | Filtrar por deporte(s), separados por comas (p. ej. `basketball,baseball`). |
+| `league` | string | todas | Filtrar por liga(s), separadas por comas (p. ej. `nba,mlb`). |
 | `sportsbook` | string | todas | Filtrar por casa(s) de apuestas, separadas por comas. |
+| `devig_book` | string | todas | Filtrar por la referencia sharp contra la que se valoró la selección (p. ej. `pinnacle`). |
 
-### Ventana de fechas
+### Ventana de histórico por nivel
 
-El nivel Sharp permite hasta **30 días** de histórico (la ventana de retención actual para los datos de líneas de cierre). Las fechas solicitadas fuera de esta ventana se limitan silenciosamente a la fecha más antigua disponible.
+Los rangos de fechas se limitan a la ventana de retroceso de tu nivel (reflejada en `meta.tier_window_days`):
+
+| Nivel | Ventana |
+|------|--------|
+| Free | 7 días |
+| Hobby | 30 días |
+| Pro | 90 días |
+| Sharp | 365 días |
+| Enterprise | Ilimitada |
+
+<Callout type="info">
+**Filtra por `devig_book=pinnacle` para obtener la señal significativa.** La validez del CLV está dominada por la referencia sharp contra la que se valoró la selección. El CLV referenciado a Pinnacle es la serie predictiva; las selecciones valoradas contra referencias de respaldo (p. ej. `bookmaker`) presentan un CLV estructuralmente negativo y no deben interpretarse como ventaja. Agrupa por `devig_book` para ver la diferencia.
+</Callout>
 
 ## Ejemplos de solicitudes
 
@@ -57,32 +62,39 @@ El nivel Sharp permite hasta **30 días** de histórico (la ventana de retenció
   <Tabs.Tab>
 ```bash
 # CLV por casa de apuestas durante los últimos 7 días
-curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?from=2026-04-10&to=2026-04-17&group_by=sportsbook" \
+curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?group_by=sportsbook" \
   -H "X-API-Key: YOUR_API_KEY"
 
-# CLV agrupado por deporte, solo NBA
-curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?league=nba&group_by=sport" \
+# Solo CLV referenciado a Pinnacle, agrupado por deporte
+curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?devig_book=pinnacle&group_by=sport" \
   -H "X-API-Key: YOUR_API_KEY"
 
-# CLV agrupado por día para DraftKings
-curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?sportsbook=draftkings&group_by=day" \
+# CLV día a día para las selecciones de DraftKings en un rango de fechas
+curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?sportsbook=draftkings&group_by=day&from=2026-06-01&to=2026-06-08" \
   -H "X-API-Key: YOUR_API_KEY"
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```javascript
 const params = new URLSearchParams({
-  from: '2026-04-10',
-  to: '2026-04-17',
+  devig_book: 'pinnacle',
   group_by: 'sportsbook',
 });
 const response = await fetch(
   `https://api.sharpapi.io/api/v1/historical/clv?${params}`,
   { headers: { 'X-API-Key': 'YOUR_API_KEY' } }
 );
-const { data, meta } = await response.json();
+const { data } = await response.json();
 for (const group of data.groups) {
-  console.log(`${group.group_key}: avg CLV ${group.avg_clv_percent.toFixed(2)}% (${group.samples} samples)`);
+  // avg_clv_percent, avg_ev_percent y win_rate son null cuando un grupo
+  // no tiene filas calificadas / liquidadas — comprueba antes de formatear.
+  const clv = group.avg_clv_percent !== null
+    ? `${group.avg_clv_percent.toFixed(2)}%`
+    : 'n/a';
+  const wr = group.win_rate !== null
+    ? `${(group.win_rate * 100).toFixed(1)}% over ${group.wins + group.losses} settled`
+    : 'no settled bets';
+  console.log(`${group.group_key}: avg CLV ${clv} (${group.total_graded} graded), win rate ${wr}`);
 }
 ```
   </Tabs.Tab>
@@ -92,20 +104,24 @@ import requests
 
 response = requests.get(
     'https://api.sharpapi.io/api/v1/historical/clv',
-    params={
-        'from': '2026-04-10',
-        'to': '2026-04-17',
-        'group_by': 'sportsbook',
-    },
-    headers={'X-API-Key': 'YOUR_API_KEY'}
+    params={'devig_book': 'pinnacle', 'group_by': 'sportsbook'},
+    headers={'X-API-Key': 'YOUR_API_KEY'},
 )
-data = response.json()
-for group in data['data']['groups']:
-    print(
-        f"{group['group_key']}: "
-        f"avg CLV {group['avg_clv_percent']:.2f}% "
-        f"({group['samples']} samples)"
+payload = response.json()
+for group in payload['data']['groups']:
+    # avg_clv_percent / avg_ev_percent / win_rate son None cuando un grupo
+    # no tiene filas calificadas / liquidadas — comprueba antes de formatear.
+    clv = (
+        f"{group['avg_clv_percent']:.2f}%"
+        if group['avg_clv_percent'] is not None else 'n/a'
     )
+    settled = group['wins'] + group['losses']
+    wr = (
+        f"{group['win_rate'] * 100:.1f}% over {settled} settled"
+        if group['win_rate'] is not None else 'no settled bets'
+    )
+    print(f"{group['group_key']}: avg CLV {clv} "
+          f"({group['total_graded']} graded), win rate {wr}")
 ```
   </Tabs.Tab>
 </Tabs>
@@ -118,74 +134,54 @@ for group in data['data']['groups']:
 {
   "success": true,
   "data": {
+    "date_range": {
+      "from": "2026-06-03T14:12:30.437",
+      "to": "2026-06-10T14:12:30.437"
+    },
     "group_by": "sportsbook",
     "groups": [
       {
-        "group_key": "draftkings",
-        "samples": 312,
-        "avg_clv_percent": 1.42,
-        "avg_abs_clv_percent": 2.18,
-        "distinct_books": 1,
-        "distinct_sports": 4
+        "group_key": "novig",
+        "total_graded": 1294,
+        "wins": 262,
+        "losses": 200,
+        "win_rate": 0.5670995670995671,
+        "avg_clv_percent": 0.673342797764432,
+        "avg_ev_percent": 1.613983921390446,
+        "total_predictions": 1555
       },
       {
-        "group_key": "fanduel",
-        "samples": 289,
-        "avg_clv_percent": 0.87,
-        "avg_abs_clv_percent": 1.95,
-        "distinct_books": 1,
-        "distinct_sports": 4
-      },
-      {
-        "group_key": "betmgm",
-        "samples": 201,
-        "avg_clv_percent": -0.21,
-        "avg_abs_clv_percent": 1.74,
-        "distinct_books": 1,
-        "distinct_sports": 3
+        "group_key": "prophetx",
+        "total_graded": 964,
+        "wins": 191,
+        "losses": 214,
+        "win_rate": 0.47160493827160493,
+        "avg_clv_percent": 0.07641414602522267,
+        "avg_ev_percent": 1.4343012769214647,
+        "total_predictions": 1331
       }
-    ],
-    "date_range": {
-      "from": "2026-04-10T00:00:00.000",
-      "to": "2026-04-17T00:00:00.000"
-    },
-    "total_events": 58,
-    "comparable_events": 51,
-    "sharp_reference": "pinnacle"
+    ]
   },
   "meta": {
-    "source": "valkey:closing_line",
-    "tier_window_days": 30,
-    "phase": "1",
     "filters": {
-      "sport": null,
+      "devig_book": null,
+      "group_by": "sportsbook",
       "league": null,
-      "sportsbook": null,
-      "group_by": "sportsbook"
+      "sport": null,
+      "sportsbook": null
     },
-    "updated_at": "2026-04-17T20:00:00.000000000Z"
+    "source": "clickhouse",
+    "tier_window_days": "unlimited",
+    "updated_at": "2026-06-10T14:12:58.75061216Z"
   }
 }
 ```
 
-**Resultado vacío (sin datos de línea de cierre todavía):**
+Un array `groups` vacío es una respuesta válida cuando no existen predicciones calificadas para los filtros y el rango de fechas solicitados — no es un error.
 
-```json
-{
-  "success": true,
-  "data": {
-    "group_by": "sportsbook",
-    "groups": [],
-    "date_range": { "from": "...", "to": "..." },
-    "total_events": 0,
-    "comparable_events": 0,
-    "sharp_reference": "pinnacle"
-  },
-  "meta": { "source": "valkey:closing_line", "phase": "1", ... }
-}
-```
-
-Un array `groups` vacío es una respuesta válida cuando no se han capturado datos de línea de cierre para el rango de fechas solicitado — no es un error.
+<Callout type="warning">
+**Tres recuentos distintos — no mezcles denominadores.** `total_predictions` cuenta todas las selecciones rastreadas (incluidas las que nunca se calificaron). `total_graded` cuenta las selecciones con una **calificación de CLV** (se capturó y comparó una línea de cierre). `wins + losses` cuenta el subconjunto, normalmente más pequeño, cuyo **resultado del partido** también está liquidado — y `win_rate` se calcula solo sobre ese subconjunto. Un grupo puede mostrar legítimamente `total_graded: 1294` junto a `wins + losses: 462`. `win_rate` es `null` cuando un grupo no tiene apuestas liquidadas.
+</Callout>
 
 ### Respuestas de error
 
@@ -194,9 +190,10 @@ Un array `groups` vacío es una respuesta válida cuando no se han capturado dat
 {
   "error": {
     "code": "tier_restricted",
-    "message": "The 'closing_lines' feature requires Sharp or higher.",
-    "required_tier": "sharp",
-    "docs": "https://docs.sharpapi.io/en/pricing"
+    "message": "This endpoint requires Enterprise tier or higher",
+    "docs": "https://sharpapi.io/pricing",
+    "tier": "pro",
+    "required_tier": "enterprise"
   }
 }
 ```
@@ -206,7 +203,7 @@ Un array `groups` vacío es una respuesta válida cuando no se han capturado dat
 {
   "error": {
     "code": "validation_error",
-    "message": "Invalid group_by. Must be one of: day, league, market, sport, sportsbook"
+    "message": "Invalid group_by. Must be one of: day, devig_book, league, market, sport, sportsbook"
   }
 }
 ```
@@ -217,31 +214,30 @@ Un array `groups` vacío es una respuesta válida cuando no se han capturado dat
 
 | Campo | Tipo | Descripción |
 |-------|------|-------------|
-| `group_by` | string | La dimensión utilizada para la agregación |
-| `groups` | array | Array de filas de grupo, ordenadas por `samples` de forma descendente |
 | `date_range` | object | `from`/`to` reales utilizados tras la limitación por nivel |
-| `total_events` | integer | Total de eventos encontrados en el rango de fechas (antes del filtro de Pinnacle) |
-| `comparable_events` | integer | Eventos con una línea de cierre de Pinnacle disponible para comparación |
-| `sharp_reference` | string | Casa sharp utilizada como referencia de cuotas justas (`"pinnacle"`) |
+| `group_by` | string | La dimensión utilizada para la agregación |
+| `groups` | array | Array de filas de grupo |
 
 ### Campos de la fila de grupo
 
 | Campo | Tipo | Descripción |
 |-------|------|-------------|
-| `group_key` | string | El identificador del grupo (nombre de la casa de apuestas, deporte, liga, tipo de mercado o fecha YYYY-MM-DD) |
-| `samples` | integer | Número de comparaciones de líneas de cierre en este grupo |
-| `avg_clv_percent` | number | CLV% medio de todas las muestras. Positivo = la casa cerró más laxa que Pinnacle. |
-| `avg_abs_clv_percent` | number | CLV% absoluto medio (medida de eficiencia de mercado independiente de la dirección) |
-| `distinct_books` | integer | Número de casas de apuestas distintas en este grupo |
-| `distinct_sports` | integer | Número de deportes distintos en este grupo |
+| `group_key` | string | El identificador del grupo (nombre de la casa de apuestas, deporte, liga, tipo de mercado, fecha `YYYY-MM-DD` o devig book) |
+| `total_graded` | integer | Predicciones lógicas con una calificación de CLV (línea de cierre capturada y comparada) |
+| `wins` | integer | Predicciones calificadas cuyo resultado del partido se liquidó como victoria |
+| `losses` | integer | Predicciones calificadas cuyo resultado del partido se liquidó como derrota |
+| `win_rate` | number \| null | `wins / (wins + losses)`. Calculado solo sobre el subconjunto liquidado; `null` cuando no existen apuestas liquidadas en el grupo |
+| `avg_clv_percent` | number \| null | CLV% medio de las predicciones calificadas. Positivo = los precios detectados batieron al cierre en promedio. `null` cuando no es calculable |
+| `avg_ev_percent` | number \| null | Valor esperado % medio en el momento de la detección para las predicciones del grupo. `null` cuando no es calculable |
+| `total_predictions` | integer | Todas las predicciones rastreadas en el grupo, incluidas las que (todavía) no han sido calificadas |
 
 ### Objeto `meta`
 
 | Campo | Tipo | Descripción |
 |-------|------|-------------|
-| `source` | string | Siempre `"valkey:closing_line"` (backend de la Fase 1) |
-| `tier_window_days` | integer | Días máximos de retroceso para tu nivel (Sharp = 30) |
-| `phase` | string | `"1"` — captura en tiempo real desde las transiciones a en directo. Backfill desde ClickHouse previsto para la Fase 2. |
+| `filters` | object | Eco de los filtros aplicados (`sport`, `league`, `sportsbook`, `devig_book`, `group_by`); `null` para los filtros no utilizados |
+| `source` | string | `"clickhouse"` — el almacén de analítica histórica |
+| `tier_window_days` | integer \| string | Retroceso máximo para tu nivel (p. ej. `90`), o `"unlimited"` |
 | `updated_at` | string | Marca de tiempo de la respuesta en formato ISO 8601 |
 
 ---
@@ -250,15 +246,23 @@ Un array `groups` vacío es una respuesta válida cuando no se han capturado dat
 
 | CLV% | Interpretación |
 |------|----------------|
-| **> +2%** | La casa cerró sistemáticamente con precios significativamente más laxos que las líneas sharp — alto valor capturado |
-| **+0,5% a +2%** | La casa cerró ligeramente laxa — típico de las casas recreativas |
-| **-0,5% a +0,5%** | Cierre próximo al mercado — eficiente o mixto |
-| **< -0,5%** | La casa se ajustó hacia el cierre — puede indicar persecución de steam o acción del lado sharp |
+| **> +2%** | Los precios detectados batieron sistemáticamente al cierre por un margen amplio — alto valor capturado |
+| **+0,5% a +2%** | Los precios batieron modestamente al cierre — típico de las casas soft frente a una referencia sharp |
+| **-0,5% a +0,5%** | Próximo al mercado — precios eficientes o resultados mixtos |
+| **< -0,5%** | Los precios se ajustaron hacia el cierre — steam tardío o acción del lado sharp |
 
-Un CLV medio positivo en tus apuestas es el indicador más sólido de que estás apostando a precios ineficientes. Sobre una muestra grande, un CLV positivo predice fuertemente un ROI positivo.
+<Callout type="info">
+**El CLV no es ROI — léelo con las salvedades adecuadas.**
+
+- **La eficiencia del mercado varía.** En los mercados más sharp y líquidos (por ejemplo los spreads y totales de la NBA, y los props de jugador de las grandes ligas), batir al cierre **no** se convierte de forma fiable en beneficio realizado — allí, batir la línea de cierre suele reflejar ruido en un mercado eficiente más que ventaja. En mercados más soft, un CLV positivo sigue siendo el mejor indicador adelantado de rentabilidad a largo plazo.
+- **Usa `win_rate` junto con `avg_clv_percent`.** El endpoint devuelve resultados realizados exactamente por esta razón: un grupo con CLV positivo pero con un historial liquidado por debajo del punto de equilibrio sobre una muestra grande te está diciendo que el CLV ahí no se está convirtiendo.
+- **Cuidado con el tamaño de la muestra.** Los grupos con un `total_graded` pequeño o pocas apuestas liquidadas (`wins + losses`) son ruido — compara grupos solo con un volumen significativo.
+- **La referencia sharp importa.** Solo el CLV referenciado a una casa sharp (filtra `devig_book=pinnacle`) tiene este significado; las filas referenciadas a respaldos no.
+</Callout>
 
 ## Endpoints relacionados
 
-- [Cuotas de cierre por fecha](/es/api-reference/historical-odds-closing/) — Precios de cierre brutos por evento para una fecha determinada
+- [Cuotas de cierre](/es/api-reference/odds-closing/) — Precios de cierre brutos por evento (nivel Pro y superiores)
+- [Cuotas de cierre por fecha](/es/api-reference/historical-odds-closing/) — Precios de cierre históricos por evento para una fecha determinada
 - [Oportunidades +EV](/es/api-reference/opportunities-ev/) — Apuestas de valor esperado positivo en tiempo real
 - [Snapshot de cuotas](/es/api-reference/odds/) — Cuotas pre-match y en directo actuales

--- a/content/pt-BR/api-reference/historical-clv.mdx
+++ b/content/pt-BR/api-reference/historical-clv.mdx
@@ -1,55 +1,60 @@
 ---
-description: "GET /api/v1/historical/clv — Análise de Closing Line Value entre sportsbooks. Compare seus preços de fechamento com a probabilidade no-vig da Pinnacle para medir a vantagem. Tier Sharp obrigatório."
+description: "GET /api/v1/historical/clv — Análise de Closing Line Value das previsões +EV avaliadas da SharpAPI, agrupadas por sportsbook, esporte, liga, mercado, dia ou referência sharp (devig_book). Tier Enterprise."
 ---
 
 import { Callout, Tabs } from 'nextra/components'
 
 # Closing Line Value (CLV)
 
-Analise o quão bem as odds de fechamento de um sportsbook se comparam com a probabilidade devigada (no-vig) da Pinnacle. CLV positivo significa que o book fechou mais frouxo que a Pinnacle — um proxy histórico para vantagem (edge).
+Estatísticas agregadas de Closing Line Value para as previsões +EV avaliadas (graded) da SharpAPI. Para cada oportunidade +EV que o engine sinaliza, o sistema captura posteriormente a linha de fechamento da referência sharp e avalia o palpite contra ela — este endpoint serve essas avaliações, agregadas pela dimensão que você escolher (`group_by`), junto com os resultados realizados de vitória/derrota quando o resultado do jogo é conhecido.
 
 ```
 GET /api/v1/historical/clv
 ```
 
 <Callout type="warning">
-**Tier Sharp ou superior obrigatório.** Os tiers Pro e inferiores recebem um erro `403 tier_restricted`. Este endpoint é controlado pela feature `closing_lines`.
+**Tier Enterprise obrigatório.** Os endpoints agregados `/api/v1/historical/*` são controlados pela feature `history`. Tiers inferiores recebem `403 tier_restricted`. Se você está no **Pro ou Sharp** e quer dados de linha de fechamento, use [Closing Odds](/pt-BR/api-reference/odds-closing/) — preços de fechamento brutos por evento, disponíveis no seu tier.
 </Callout>
 
-<Callout type="info">
-**Janela de dados da Fase 1:** As linhas de fechamento são capturadas em tempo real conforme os jogos entram ao vivo. O armazenamento Valkey retém os dados por **30 dias**. Dados históricos além de 30 dias ainda não estão disponíveis.
-</Callout>
+## Como o CLV é calculado
 
-## Como as Linhas de Fechamento São Capturadas
-
-Quando um jogo passa de pré-partida para ao vivo, o servidor captura as últimas odds de pré-partida de cada book como a linha de fechamento daquele evento. O preço de fechamento é devigado usando o **método Power** (o mesmo do cálculo de EV) para produzir uma probabilidade no-vig por seleção.
-
-O CLV é então calculado como:
+Quando um evento passa de pré-partida para ao vivo, a plataforma captura o último preço pré-partida de cada book como a linha de fechamento daquele evento. O preço de fechamento da **referência sharp** (`devig_book` — tipicamente a Pinnacle) é devigado com o método Power para uma probabilidade de fechamento no-vig, e cada previsão avaliada recebe a pontuação:
 
 ```
-CLV% = (pin_no_vig_prob - book_no_vig_prob) / book_no_vig_prob × 100
+CLV% = (closing_no_vig_prob × entry_decimal_odds − 1) × 100
 ```
 
-Onde `pin_no_vig_prob` é a probabilidade devigada da Pinnacle (a referência sharp) e `book_no_vig_prob` é a probabilidade devigada do book recreativo (soft book). Um CLV% positivo significa que o book recreativo fechou em um preço mais favorável do que a linha justa da Pinnacle.
+onde `entry_decimal_odds` é o preço no momento em que a SharpAPI sinalizou a oportunidade. **CLV positivo significa que o preço sinalizado venceu o fechamento** — você poderia ter apostado em odds melhores do que o valor justo final implícito pelo mercado.
 
-## Autenticação
-
-Requer API key. **Tier Sharp ou superior obrigatório** (feature `closing_lines`).
+Os dados são servidos a partir do armazenamento histórico em ClickHouse. As agregações são calculadas sobre **previsões lógicas** — snapshots de preço repetidos do mesmo palpite (mesmo evento, mercado, seleção, book, linha) são colapsados em uma única linha antes da contagem, de modo que um palpite reobservado em vários preços não é contado múltiplas vezes.
 
 ## Parâmetros de Query
 
 | Parâmetro | Tipo | Padrão | Descrição |
 |-----------|------|---------|-------------|
-| `from` | string | 7 dias atrás | Data inicial (`YYYY-MM-DD` ou ISO 8601). Limitada à janela de 30 dias. |
+| `from` | string | 7 dias atrás | Data inicial (`YYYY-MM-DD` ou ISO 8601). Limitada à janela de histórico do seu tier. |
 | `to` | string | hoje | Data final (`YYYY-MM-DD` ou ISO 8601). |
-| `group_by` | string | `sportsbook` | Dimensão de agregação. Uma de: `sportsbook`, `sport`, `league`, `market`, `day`. |
-| `sport` | string | todos | Filtra por esporte(s), separados por vírgula (ex.: `basketball,football`). |
-| `league` | string | todas | Filtra por liga(s), separadas por vírgula (ex.: `nba,nfl`). |
+| `group_by` | string | `sportsbook` | Dimensão de agregação. Uma de: `sportsbook`, `sport`, `league`, `market`, `day`, `devig_book`. |
+| `sport` | string | todos | Filtra por esporte(s), separados por vírgula (ex.: `basketball,baseball`). |
+| `league` | string | todas | Filtra por liga(s), separadas por vírgula (ex.: `nba,mlb`). |
 | `sportsbook` | string | todos | Filtra por sportsbook(s), separados por vírgula. |
+| `devig_book` | string | todas | Filtra pela referência sharp contra a qual o palpite foi precificado (ex.: `pinnacle`). |
 
-### Janela de Datas
+### Janela de histórico por tier
 
-O tier Sharp permite até **30 dias** de histórico (a janela atual de retenção para dados de linha de fechamento). Solicitar datas fora dessa janela é silenciosamente ajustado para a data mais antiga disponível.
+Os intervalos de datas são limitados à janela de lookback do seu tier (refletida em `meta.tier_window_days`):
+
+| Tier | Janela |
+|------|--------|
+| Free | 7 dias |
+| Hobby | 30 dias |
+| Pro | 90 dias |
+| Sharp | 365 dias |
+| Enterprise | Ilimitada |
+
+<Callout type="info">
+**Filtre por `devig_book=pinnacle` para obter o sinal que importa.** A validade do CLV é dominada pela referência sharp contra a qual o palpite foi precificado. O CLV referenciado na Pinnacle é a série preditiva; palpites precificados contra referências de fallback (ex.: `bookmaker`) carregam CLV estruturalmente negativo e não devem ser lidos como vantagem (edge). Agrupe por `devig_book` para ver a separação.
+</Callout>
 
 ## Exemplos de Requisições
 
@@ -57,32 +62,39 @@ O tier Sharp permite até **30 dias** de histórico (a janela atual de retençã
   <Tabs.Tab>
 ```bash
 # CLV por sportsbook nos últimos 7 dias
-curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?from=2026-04-10&to=2026-04-17&group_by=sportsbook" \
+curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?group_by=sportsbook" \
   -H "X-API-Key: YOUR_API_KEY"
 
-# CLV agrupado por esporte, apenas NBA
-curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?league=nba&group_by=sport" \
+# Apenas CLV referenciado na Pinnacle, agrupado por esporte
+curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?devig_book=pinnacle&group_by=sport" \
   -H "X-API-Key: YOUR_API_KEY"
 
-# CLV agrupado por dia para a DraftKings
-curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?sportsbook=draftkings&group_by=day" \
+# CLV dia a dia para palpites na DraftKings em um intervalo de datas
+curl -X GET "https://api.sharpapi.io/api/v1/historical/clv?sportsbook=draftkings&group_by=day&from=2026-06-01&to=2026-06-08" \
   -H "X-API-Key: YOUR_API_KEY"
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```javascript
 const params = new URLSearchParams({
-  from: '2026-04-10',
-  to: '2026-04-17',
+  devig_book: 'pinnacle',
   group_by: 'sportsbook',
 });
 const response = await fetch(
   `https://api.sharpapi.io/api/v1/historical/clv?${params}`,
   { headers: { 'X-API-Key': 'YOUR_API_KEY' } }
 );
-const { data, meta } = await response.json();
+const { data } = await response.json();
 for (const group of data.groups) {
-  console.log(`${group.group_key}: avg CLV ${group.avg_clv_percent.toFixed(2)}% (${group.samples} samples)`);
+  // avg_clv_percent, avg_ev_percent e win_rate são null quando um grupo
+  // não tem linhas avaliadas / liquidadas — proteja antes de formatar.
+  const clv = group.avg_clv_percent !== null
+    ? `${group.avg_clv_percent.toFixed(2)}%`
+    : 'n/a';
+  const wr = group.win_rate !== null
+    ? `${(group.win_rate * 100).toFixed(1)}% over ${group.wins + group.losses} settled`
+    : 'no settled bets';
+  console.log(`${group.group_key}: avg CLV ${clv} (${group.total_graded} graded), win rate ${wr}`);
 }
 ```
   </Tabs.Tab>
@@ -92,20 +104,24 @@ import requests
 
 response = requests.get(
     'https://api.sharpapi.io/api/v1/historical/clv',
-    params={
-        'from': '2026-04-10',
-        'to': '2026-04-17',
-        'group_by': 'sportsbook',
-    },
-    headers={'X-API-Key': 'YOUR_API_KEY'}
+    params={'devig_book': 'pinnacle', 'group_by': 'sportsbook'},
+    headers={'X-API-Key': 'YOUR_API_KEY'},
 )
-data = response.json()
-for group in data['data']['groups']:
-    print(
-        f"{group['group_key']}: "
-        f"avg CLV {group['avg_clv_percent']:.2f}% "
-        f"({group['samples']} samples)"
+payload = response.json()
+for group in payload['data']['groups']:
+    # avg_clv_percent / avg_ev_percent / win_rate são None quando um grupo
+    # não tem linhas avaliadas / liquidadas — proteja antes de formatar.
+    clv = (
+        f"{group['avg_clv_percent']:.2f}%"
+        if group['avg_clv_percent'] is not None else 'n/a'
     )
+    settled = group['wins'] + group['losses']
+    wr = (
+        f"{group['win_rate'] * 100:.1f}% over {settled} settled"
+        if group['win_rate'] is not None else 'no settled bets'
+    )
+    print(f"{group['group_key']}: avg CLV {clv} "
+          f"({group['total_graded']} graded), win rate {wr}")
 ```
   </Tabs.Tab>
 </Tabs>
@@ -118,74 +134,54 @@ for group in data['data']['groups']:
 {
   "success": true,
   "data": {
+    "date_range": {
+      "from": "2026-06-03T14:12:30.437",
+      "to": "2026-06-10T14:12:30.437"
+    },
     "group_by": "sportsbook",
     "groups": [
       {
-        "group_key": "draftkings",
-        "samples": 312,
-        "avg_clv_percent": 1.42,
-        "avg_abs_clv_percent": 2.18,
-        "distinct_books": 1,
-        "distinct_sports": 4
+        "group_key": "novig",
+        "total_graded": 1294,
+        "wins": 262,
+        "losses": 200,
+        "win_rate": 0.5670995670995671,
+        "avg_clv_percent": 0.673342797764432,
+        "avg_ev_percent": 1.613983921390446,
+        "total_predictions": 1555
       },
       {
-        "group_key": "fanduel",
-        "samples": 289,
-        "avg_clv_percent": 0.87,
-        "avg_abs_clv_percent": 1.95,
-        "distinct_books": 1,
-        "distinct_sports": 4
-      },
-      {
-        "group_key": "betmgm",
-        "samples": 201,
-        "avg_clv_percent": -0.21,
-        "avg_abs_clv_percent": 1.74,
-        "distinct_books": 1,
-        "distinct_sports": 3
+        "group_key": "prophetx",
+        "total_graded": 964,
+        "wins": 191,
+        "losses": 214,
+        "win_rate": 0.47160493827160493,
+        "avg_clv_percent": 0.07641414602522267,
+        "avg_ev_percent": 1.4343012769214647,
+        "total_predictions": 1331
       }
-    ],
-    "date_range": {
-      "from": "2026-04-10T00:00:00.000",
-      "to": "2026-04-17T00:00:00.000"
-    },
-    "total_events": 58,
-    "comparable_events": 51,
-    "sharp_reference": "pinnacle"
+    ]
   },
   "meta": {
-    "source": "valkey:closing_line",
-    "tier_window_days": 30,
-    "phase": "1",
     "filters": {
-      "sport": null,
+      "devig_book": null,
+      "group_by": "sportsbook",
       "league": null,
-      "sportsbook": null,
-      "group_by": "sportsbook"
+      "sport": null,
+      "sportsbook": null
     },
-    "updated_at": "2026-04-17T20:00:00.000000000Z"
+    "source": "clickhouse",
+    "tier_window_days": "unlimited",
+    "updated_at": "2026-06-10T14:12:58.75061216Z"
   }
 }
 ```
 
-**Resultado vazio (sem dados de linha de fechamento ainda):**
+Um array `groups` vazio é uma resposta válida quando não existem previsões avaliadas para os filtros e o intervalo de datas solicitados — não é um erro.
 
-```json
-{
-  "success": true,
-  "data": {
-    "group_by": "sportsbook",
-    "groups": [],
-    "date_range": { "from": "...", "to": "..." },
-    "total_events": 0,
-    "comparable_events": 0,
-    "sharp_reference": "pinnacle"
-  },
-  "meta": { "source": "valkey:closing_line", "phase": "1", ... }
-}
-```
-
-Um array `groups` vazio é uma resposta válida quando nenhum dado de linha de fechamento foi capturado para o intervalo de datas solicitado — não é um erro.
+<Callout type="warning">
+**Três contagens diferentes — não misture denominadores.** `total_predictions` conta cada palpite rastreado (incluindo os que nunca foram avaliados). `total_graded` conta palpites com uma **nota de CLV** (uma linha de fechamento foi capturada e comparada). `wins + losses` conta o subconjunto tipicamente menor cujo **resultado do jogo** também está liquidado — e `win_rate` é calculado apenas sobre esse subconjunto. Um grupo pode legitimamente exibir `total_graded: 1294` ao lado de `wins + losses: 462`. `win_rate` é `null` quando um grupo não tem apostas liquidadas.
+</Callout>
 
 ### Respostas de Erro
 
@@ -194,9 +190,10 @@ Um array `groups` vazio é uma resposta válida quando nenhum dado de linha de f
 {
   "error": {
     "code": "tier_restricted",
-    "message": "The 'closing_lines' feature requires Sharp or higher.",
-    "required_tier": "sharp",
-    "docs": "https://docs.sharpapi.io/en/pricing"
+    "message": "This endpoint requires Enterprise tier or higher",
+    "docs": "https://sharpapi.io/pricing",
+    "tier": "pro",
+    "required_tier": "enterprise"
   }
 }
 ```
@@ -206,7 +203,7 @@ Um array `groups` vazio é uma resposta válida quando nenhum dado de linha de f
 {
   "error": {
     "code": "validation_error",
-    "message": "Invalid group_by. Must be one of: day, league, market, sport, sportsbook"
+    "message": "Invalid group_by. Must be one of: day, devig_book, league, market, sport, sportsbook"
   }
 }
 ```
@@ -217,31 +214,30 @@ Um array `groups` vazio é uma resposta válida quando nenhum dado de linha de f
 
 | Campo | Tipo | Descrição |
 |-------|------|-------------|
-| `group_by` | string | A dimensão usada para agregação |
-| `groups` | array | Array de linhas de grupo, ordenadas por `samples` em ordem decrescente |
 | `date_range` | object | Valores `from`/`to` efetivamente usados após o ajuste de tier |
-| `total_events` | integer | Total de eventos encontrados no intervalo de datas (antes do filtro da Pinnacle) |
-| `comparable_events` | integer | Eventos com uma linha de fechamento da Pinnacle disponível para comparação |
-| `sharp_reference` | string | Sharp book usado como referência de odds justas (`"pinnacle"`) |
+| `group_by` | string | A dimensão usada para agregação |
+| `groups` | array | Array de linhas de grupo |
 
 ### Campos da linha de grupo
 
 | Campo | Tipo | Descrição |
 |-------|------|-------------|
-| `group_key` | string | O identificador do grupo (nome do sportsbook, esporte, liga, tipo de mercado ou data YYYY-MM-DD) |
-| `samples` | integer | Número de comparações de linha de fechamento neste grupo |
-| `avg_clv_percent` | number | CLV% médio entre todas as amostras. Positivo = book fechou mais frouxo que a Pinnacle. |
-| `avg_abs_clv_percent` | number | CLV% absoluto médio (medida de eficiência de mercado independente de direção) |
-| `distinct_books` | integer | Número de books distintos neste grupo |
-| `distinct_sports` | integer | Número de esportes distintos neste grupo |
+| `group_key` | string | O identificador do grupo (nome do sportsbook, esporte, liga, tipo de mercado, data `YYYY-MM-DD` ou devig book) |
+| `total_graded` | integer | Previsões lógicas com nota de CLV (linha de fechamento capturada e comparada) |
+| `wins` | integer | Previsões avaliadas cujo resultado do jogo liquidou como vitória |
+| `losses` | integer | Previsões avaliadas cujo resultado do jogo liquidou como derrota |
+| `win_rate` | number \| null | `wins / (wins + losses)`. Calculado apenas sobre o subconjunto liquidado; `null` quando não há apostas liquidadas no grupo |
+| `avg_clv_percent` | number \| null | CLV% médio entre as previsões avaliadas. Positivo = os preços sinalizados venceram o fechamento em média. `null` quando não computável |
+| `avg_ev_percent` | number \| null | Valor esperado % médio no momento da detecção para as previsões do grupo. `null` quando não computável |
+| `total_predictions` | integer | Todas as previsões rastreadas no grupo, incluindo as ainda não avaliadas |
 
 ### Objeto `meta`
 
 | Campo | Tipo | Descrição |
 |-------|------|-------------|
-| `source` | string | Sempre `"valkey:closing_line"` (backend da Fase 1) |
-| `tier_window_days` | integer | Máximo de dias de lookback para o seu tier (Sharp = 30) |
-| `phase` | string | `"1"` — captura em tempo real a partir das transições para ao vivo. Backfill via ClickHouse planejado para a Fase 2. |
+| `filters` | object | Eco dos filtros aplicados (`sport`, `league`, `sportsbook`, `devig_book`, `group_by`); `null` para filtros não usados |
+| `source` | string | `"clickhouse"` — o armazenamento de análises históricas |
+| `tier_window_days` | integer \| string | Lookback máximo para o seu tier (ex.: `90`), ou `"unlimited"` |
 | `updated_at` | string | Timestamp ISO 8601 da resposta |
 
 ---
@@ -250,15 +246,23 @@ Um array `groups` vazio é uma resposta válida quando nenhum dado de linha de f
 
 | CLV% | Interpretação |
 |------|----------------|
-| **> +2%** | Book fechou consistentemente muito mais frouxo que linhas sharp — alto valor capturado |
-| **+0,5% a +2%** | Book fechou ligeiramente frouxo — típico de books recreativos |
-| **-0,5% a +0,5%** | Fechamento próximo ao mercado — eficiente ou misto |
-| **< -0,5%** | Book apertou no fechamento — pode indicar steam chasing ou ação do lado sharp |
+| **> +2%** | Os preços sinalizados venceram o fechamento consistentemente por margem ampla — forte valor capturado |
+| **+0,5% a +2%** | Os preços venceram o fechamento modestamente — típico de books recreativos contra uma referência sharp |
+| **-0,5% a +0,5%** | Próximo ao mercado — precificação eficiente ou resultados mistos |
+| **< -0,5%** | Os preços apertaram rumo ao fechamento — steam tardio ou ação do lado sharp |
 
-Um CLV médio positivo nas suas apostas é o indicador mais forte de que você está apostando em preços ineficientes. Em uma amostra grande, CLV positivo prevê fortemente ROI positivo.
+<Callout type="info">
+**CLV não é ROI — leia-o com as ressalvas certas.**
+
+- **A eficiência de mercado varia.** Nos mercados mais sharp e líquidos (por exemplo, spreads e totais da NBA, e player props das ligas principais), vencer o fechamento **não** se converte de forma confiável em lucro realizado — vitórias sobre a linha de fechamento nesses mercados frequentemente refletem ruído em um mercado eficiente, e não vantagem. Em mercados mais soft, CLV positivo continua sendo o melhor indicador antecedente de lucratividade no longo prazo.
+- **Use `win_rate` junto com `avg_clv_percent`.** O endpoint retorna resultados realizados exatamente por isso: um grupo com CLV positivo mas com histórico liquidado abaixo do breakeven em uma amostra grande está dizendo que o CLV ali não está se convertendo.
+- **Atenção ao tamanho da amostra.** Grupos com `total_graded` pequeno ou poucas apostas liquidadas (`wins + losses`) são ruído — compare grupos apenas em volume significativo.
+- **A referência sharp importa.** Apenas o CLV referenciado em book sharp (filtro `devig_book=pinnacle`) carrega esse significado; linhas referenciadas em fallback, não.
+</Callout>
 
 ## Endpoints Relacionados
 
-- [Closing Odds por Data](/pt-BR/api-reference/historical-odds-closing/) — Preços de fechamento brutos por evento para uma data específica
+- [Closing Odds](/pt-BR/api-reference/odds-closing/) — Preços de fechamento brutos por evento (tier Pro ou superior)
+- [Closing Odds por Data](/pt-BR/api-reference/historical-odds-closing/) — Preços de fechamento históricos por evento para uma data específica
 - [Oportunidades +EV](/pt-BR/api-reference/opportunities-ev/) — Apostas de valor esperado positivo em tempo real
 - [Snapshot de Odds](/pt-BR/api-reference/odds/) — Odds atuais pré-partida e ao vivo


### PR DESCRIPTION
## What

Roadmap **E2** (docs shape mismatch) + **E4** (market-efficiency caveat). The `historical-clv` page documented the **retired Valkey/Phase-1 backend** — a group shape (`samples`, `avg_abs_clv_percent`, `distinct_books/sports`), data fields (`total_events`, `comparable_events`, `sharp_reference`), `meta.source="valkey:closing_line"`/`phase: "1"`, a 30-day window, and a "Sharp tier / `closing_lines` feature" gate — none of which the live endpoint returns. The JS/Python examples **KeyError on `group.samples`**.

**Measured harm:** ClickHouse nginx logs show **5 distinct customer keys bounced with 403** on this endpoint in the last 60 days, following the stale tier claim.

## Rewritten against ground truth

Captured the live production response + read the `CLVHandler` source:

- **Real group shape**: `group_key`, `total_graded`, `wins`, `losses`, `win_rate` (null when no settled bets), `avg_clv_percent`/`avg_ev_percent` (nullable), `total_predictions`. Real `meta` (`source: "clickhouse"`, `tier_window_days`, filters echo). Example payload is a real production response.
- **`group_by=devig_book` + `devig_book` filter documented**, with the guidance that Pinnacle-referenced CLV is the meaningful series.
- **Correct CLV formula** (`closing_no_vig_prob × entry_decimal_odds − 1`) and the leg-dedup semantics (one logical pick = one row, post sharp-api-go#851).
- **Honest count semantics callout**: `total_predictions` vs `total_graded` vs `wins+losses` are three different denominators; `win_rate` is over the settled subset only (a group can show `total_graded: 1294` next to 462 settled — now explained instead of a contradiction).
- **Tier truth**: the `history` feature gating `/api/v1/historical/*` is **Enterprise-only in the live tier table**; Pro/Sharp readers are pointed at `/odds/closing` (which their tier includes). Per-tier history-window table (7/30/90/365/unlimited). The Sharp-vs-Enterprise intent discrepancy is filed as **sharp-api-go#871** — if the call lands on Sharp+, this page needs a one-word follow-up.
- **E4**: replaces "positive CLV strongly predicts ROI" with the market-efficiency caveat (in the sharpest markets — NBA spreads/totals, major props — CLV vs the close doesn't reliably convert to realized profit; read `win_rate` alongside `avg_clv_percent`; mind sample sizes; only sharp-referenced CLV carries the meaning).
- **Null-safe JS/Python examples** (guard `avg_clv_percent`/`win_rate` nulls).
- **de/es/pt-BR fully re-translated** to match, keeping each locale's established terminology; internal links locale-prefixed.

## Validation

Full `npm run build` (next build + locale-link fix + pagefind) passes across all 4 locales (224 pages indexed). No stale tokens (`samples`/`valkey`/`avg_abs_clv`) remain in any locale.

Refs roadmap E2+E4 (`/shared-tmp/ev-grader-roadmap-2026-06-08.md`). Vercel preview on this branch for visual review.

Type: docs