### PR TITLE
docs(ws): document 256KB snapshot frame cap + recommended client max_size

### DIFF
--- a/content/de/api-reference/websocket.mdx
+++ b/content/de/api-reference/websocket.mdx
@@ -244,7 +244,7 @@ Quoten-Snapshot pro Sportsbook. Wird einmal pro Sportsbook gesendet, wenn der `o
 ```
 
 <Callout type="info">
-Quoten werden nach Sportsbook in Chunks aufgeteilt — Sie erhalten eine `initial`-Nachricht pro Buch. Große Bücher können auf mehrere Nachrichten aufgeteilt werden (bis zu 1000 Quoten pro Nachricht). Wenn Sie keine Rohquoten benötigen, lassen Sie den `odds`-Channel weg, um diesen Schritt vollständig zu überspringen.
+Quoten werden nach Sportsbook in Chunks aufgeteilt — Sie erhalten eine `initial`-Nachricht pro Buch. Große Bücher können auf mehrere Nachrichten aufgeteilt werden (jeder Frame ist auf 256KB serialisiert begrenzt). Wenn Sie keine Rohquoten benötigen, lassen Sie den `odds`-Channel weg, um diesen Schritt vollständig zu überspringen.
 </Callout>
 
 #### `snapshot:complete`
@@ -591,6 +591,7 @@ WebSocket-Frames können auch die HTTP-ähnlichen Codes `invalid_api_key`, `tier
 |------|---------|------------|
 | `1000` | Normales Schließen | Vom Client oder Server initiiertes sauberes Schließen |
 | `1006` | Abnormales Schließen (clientseitig) | Netzwerkabbruch oder Prozesstermination — immer neu verbinden |
+| `1009` | Nachricht zu groß (clientseitig) | Das Limit Ihrer Bibliothek für eingehende Nachrichten liegt unter der Snapshot-Frame-Größe von 256KB — erhöhen Sie es (z. B. Python `websockets` `max_size`) auf mindestens 512KB |
 | `4001` | Authentifizierungsfehler | API key prüfen |
 | `4003` | Kein Streaming-Zugang | WebSocket Add-on (99 $/Monat) hinzufügen oder auf Enterprise upgraden |
 | `4029` | Stream-Limit überschritten | Ungenutzte Verbindungen schließen (Standard: 1 pro Schlüssel; neuere Verbindung gewinnt) |

--- a/content/de/streaming/websocket.mdx
+++ b/content/de/streaming/websocket.mdx
@@ -106,7 +106,7 @@ Beim Verbindungsaufbau erhalten Sie Nachrichten in folgender Reihenfolge:
 5. **`snapshot:complete`** -- Signalisiert, dass alle initialen Daten gesendet wurden
 
 <Callout type="info">
-**Snapshot-Chunking:** Große Snapshots werden auf mehrere Frames aufgeteilt, um Backpressure zu vermeiden. Quoten-Snapshots werden in Chunks von 1.000 Elementen pro Frame und Opportunitäts-Snapshots in Chunks von 300 Elementen pro Frame aufgeteilt. Warten Sie auf `snapshot:complete`, bevor Sie die initialen Daten als vollständig geladen betrachten.
+**Snapshot-Chunking & Frame-Größe:** Große Snapshots werden auf mehrere Frames aufgeteilt, um Backpressure zu vermeiden. Jeder Snapshot-Frame ist auf 256KB (serialisiert) begrenzt; Quoten-Snapshots werden zusätzlich pro Sportsbook aufgeteilt, Opportunitäts-Snapshots in bis zu 300 Elemente pro Frame. Warten Sie auf `snapshot:complete`, bevor Sie die initialen Daten als vollständig geladen betrachten. Falls Ihre Client-Bibliothek eine maximale Größe für eingehende Nachrichten erzwingt, belassen Sie diese bei mindestens 512KB — der 1MB-Standard von Python `websockets` (`max_size=2**20`) ist ausreichend. Ein Client mit einem Limit unter 256KB schließt mitten im Snapshot mit `1009 (message too big)` und gerät in eine Reconnect-Schleife, ohne jemals Daten zu empfangen.
 </Callout>
 
 Danach erhalten Sie inkrementelle Updates für Ihre abonnierten Kanäle:

--- a/content/en/api-reference/websocket.mdx
+++ b/content/en/api-reference/websocket.mdx
@@ -244,7 +244,7 @@ Per-sportsbook odds snapshot. Sent once per sportsbook when the `odds` channel i
 ```
 
 <Callout type="info">
-Odds are chunked by sportsbook — you will receive one `initial` message per book. Large books may be split across multiple messages (up to 1000 odds each). If you don't need raw odds, omit the `odds` channel to skip this entirely.
+Odds are chunked by sportsbook — you will receive one `initial` message per book. Large books may be split across multiple messages (each frame is capped at 256KB serialized). If you don't need raw odds, omit the `odds` channel to skip this entirely.
 </Callout>
 
 #### `snapshot:complete`
@@ -608,6 +608,7 @@ WebSocket frames may also carry the HTTP-style `invalid_api_key`, `tier_restrict
 |------|---------|------------|
 | `1000` | Normal close | Client or server initiated clean close |
 | `1006` | Abnormal closure (client-side) | Network drop or process kill — always reconnect |
+| `1009` | Message too big (client-side) | Your library's incoming-message cap is below the 256KB snapshot frame size — raise it (e.g. Python `websockets` `max_size`) to at least 512KB |
 | `4001` | Authentication failure | Check your API key |
 | `4003` | No streaming access | Add WebSocket add-on ($99/mo) or upgrade to Enterprise |
 | `4029` | Stream limit exceeded | Close unused connections (default: 1 per key; newer connection wins) |

--- a/content/en/streaming/websocket.mdx
+++ b/content/en/streaming/websocket.mdx
@@ -106,7 +106,7 @@ On connect you receive messages in order:
 5. **`snapshot:complete`** -- Signals all initial data has been sent
 
 <Callout type="info">
-**Snapshot chunking:** Large snapshots are split across multiple frames to prevent backpressure. Odds snapshots are chunked at 1,000 items per frame, and opportunity snapshots at 300 items per frame. Wait for `snapshot:complete` before treating the initial data as fully loaded.
+**Snapshot chunking & frame size:** Large snapshots are split across multiple frames to prevent backpressure. Every snapshot frame is capped at 256KB serialized; odds snapshots are additionally split per sportsbook, and opportunity snapshots at up to 300 items per frame. Wait for `snapshot:complete` before treating the initial data as fully loaded. If your client library enforces a maximum incoming-message size, leave it at 512KB or higher — Python `websockets`' 1MB default (`max_size=2**20`) is fine. A client capped below 256KB closes with `1009 (message too big)` mid-snapshot and will reconnect-loop without ever receiving data.
 </Callout>
 
 After that, you receive incremental updates for your subscribed channels:

--- a/content/es/api-reference/websocket.mdx
+++ b/content/es/api-reference/websocket.mdx
@@ -244,7 +244,7 @@ Snapshot de cuotas por sportsbook. Se envía una vez por sportsbook cuando el ca
 ```
 
 <Callout type="info">
-Las cuotas se fragmentan por sportsbook — recibirás un mensaje `initial` por book. Los books grandes pueden dividirse en varios mensajes (hasta 1000 cuotas cada uno). Si no necesitas las cuotas brutas, omite el canal `odds` para saltarlas por completo.
+Las cuotas se fragmentan por sportsbook — recibirás un mensaje `initial` por book. Los books grandes pueden dividirse en varios mensajes (cada frame está limitado a 256KB serializados). Si no necesitas las cuotas brutas, omite el canal `odds` para saltarlas por completo.
 </Callout>
 
 #### `snapshot:complete`
@@ -591,6 +591,7 @@ Los frames WebSocket también pueden transportar los códigos al estilo HTTP `in
 |------|---------|------------|
 | `1000` | Cierre normal | Cierre limpio iniciado por el cliente o el servidor |
 | `1006` | Cierre anormal (lado cliente) | Caída de red o terminación del proceso — reconectar siempre |
+| `1009` | Mensaje demasiado grande (lado cliente) | El límite de tamaño de mensaje entrante de tu librería está por debajo de los 256KB del frame de snapshot — súbelo (p. ej. `max_size` de Python `websockets`) a 512KB como mínimo |
 | `4001` | Fallo de autenticación | Comprueba tu API key |
 | `4003` | Sin acceso al streaming | Añade el complemento WebSocket (99 $/mes) o actualiza a Enterprise |
 | `4029` | Límite de streams superado | Cierra las conexiones no utilizadas (por defecto: 1 por clave; gana la conexión más reciente) |

--- a/content/es/streaming/websocket.mdx
+++ b/content/es/streaming/websocket.mdx
@@ -106,7 +106,7 @@ Al conectarte recibes los mensajes en este orden:
 5. **`snapshot:complete`** -- Indica que se han enviado todos los datos iniciales
 
 <Callout type="info">
-**Fragmentación de snapshots:** Los snapshots de gran tamaño se dividen en varios frames para evitar la contrapresión. Los snapshots de cuotas se fragmentan a 1.000 elementos por frame, y los de oportunidades a 300 elementos por frame. Espera al `snapshot:complete` antes de considerar que los datos iniciales se han cargado por completo.
+**Fragmentación de snapshots y tamaño de frame:** Los snapshots de gran tamaño se dividen en varios frames para evitar la contrapresión. Cada frame de snapshot está limitado a 256KB serializados; los snapshots de cuotas se dividen además por sportsbook, y los de oportunidades en hasta 300 elementos por frame. Espera al `snapshot:complete` antes de considerar que los datos iniciales se han cargado por completo. Si tu librería cliente impone un tamaño máximo de mensaje entrante, déjalo en 512KB o más — el valor por defecto de 1MB de Python `websockets` (`max_size=2**20`) es suficiente. Un cliente con un límite inferior a 256KB se cierra con `1009 (message too big)` a mitad del snapshot y entrará en un bucle de reconexión sin llegar a recibir datos.
 </Callout>
 
 A partir de ahí, recibes actualizaciones incrementales de los canales suscritos:

--- a/content/pt-BR/api-reference/websocket.mdx
+++ b/content/pt-BR/api-reference/websocket.mdx
@@ -244,7 +244,7 @@ Snapshot de odds por sportsbook. Enviado uma vez por sportsbook quando o canal `
 ```
 
 <Callout type="info">
-As odds são divididas em chunks por sportsbook — você receberá uma mensagem `initial` por book. Books grandes podem ser divididos em múltiplas mensagens (até 1000 odds cada). Se você não precisa de odds brutas, omita o canal `odds` para pular isso inteiramente.
+As odds são divididas em chunks por sportsbook — você receberá uma mensagem `initial` por book. Books grandes podem ser divididos em múltiplas mensagens (cada frame é limitado a 256KB serializados). Se você não precisa de odds brutas, omita o canal `odds` para pular isso inteiramente.
 </Callout>
 
 #### `snapshot:complete`
@@ -591,6 +591,7 @@ Os frames WebSocket também podem carregar os códigos no estilo HTTP `invalid_a
 |--------|-------------|-----------|
 | `1000` | Fechamento normal | Fechamento limpo iniciado pelo cliente ou servidor |
 | `1006` | Fechamento anormal (lado do cliente) | Queda de rede ou kill do processo — sempre reconecte |
+| `1009` | Mensagem grande demais (lado do cliente) | O limite de mensagem recebida da sua biblioteca está abaixo dos 256KB do frame de snapshot — aumente-o (ex.: `max_size` do `websockets` do Python) para pelo menos 512KB |
 | `4001` | Falha de autenticação | Verifique sua API key |
 | `4003` | Sem acesso a streaming | Adicione o add-on de WebSocket ($99/mês) ou faça upgrade para Enterprise |
 | `4029` | Limite de streams excedido | Feche conexões não utilizadas (padrão: 1 por chave; conexão mais nova vence) |

--- a/content/pt-BR/streaming/websocket.mdx
+++ b/content/pt-BR/streaming/websocket.mdx
@@ -106,7 +106,7 @@ Ao conectar, você recebe mensagens nesta ordem:
 5. **`snapshot:complete`** -- Sinaliza que todos os dados iniciais foram enviados
 
 <Callout type="info">
-**Fragmentação de snapshot:** Snapshots grandes são divididos em múltiplos frames para evitar backpressure. Snapshots de odds são fragmentados em 1.000 itens por frame, e snapshots de oportunidades em 300 itens por frame. Aguarde `snapshot:complete` antes de tratar os dados iniciais como totalmente carregados.
+**Fragmentação de snapshot e tamanho de frame:** Snapshots grandes são divididos em múltiplos frames para evitar backpressure. Cada frame de snapshot é limitado a 256KB serializados; snapshots de odds são divididos adicionalmente por sportsbook, e snapshots de oportunidades em até 300 itens por frame. Aguarde `snapshot:complete` antes de tratar os dados iniciais como totalmente carregados. Se a sua biblioteca cliente impõe um tamanho máximo de mensagem recebida, mantenha-o em 512KB ou mais — o padrão de 1MB do `websockets` do Python (`max_size=2**20`) é suficiente. Um cliente com limite abaixo de 256KB fecha com `1009 (message too big)` no meio do snapshot e entrará em um loop de reconexão sem nunca receber dados.
 </Callout>
 
 Depois disso, você recebe atualizações incrementais para os canais inscritos:


### PR DESCRIPTION
Covers item 3 of the fix sketch in Mlaz-code/sharp-api-go#896: document a recommended client max incoming-message size in the WS docs.

- **streaming/websocket.mdx**: snapshot-chunking callout now states the 256KB serialized per-frame cap and tells clients to keep their library's message-size limit ≥512KB (Python `websockets`' 1MB default is fine), with the 1009 kill-loop failure mode spelled out.
- **api-reference/websocket.mdx**: odds-chunking note updated (was "up to 1000 odds each" — stale even pre-fix, server used 2000), and a `1009` row added to the Close Codes table.
- All four locales updated: en, de, es, pt-BR.

⚠️ **Merge after Mlaz-code/sharp-api-go#898 is merged and deployed** — the 256KB cap this documents ships there.

Type: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)