### PR TITLE
docs: fix Bet365 tier + 3 audit doc gaps (c8594804) — Fixes #265

### DIFF
--- a/content/de/api-reference/odds-best.mdx
+++ b/content/de/api-reference/odds-best.mdx
@@ -38,6 +38,10 @@ Best Odds ist in allen Tarifen verfügbar, einschließlich Free. Die verglichene
 Veraltete Quoten (älter als 5 Minuten für Pre-Game, 1 Minute für Live) werden automatisch von Best-Odds-Vergleichen ausgeschlossen, um irreführende Ergebnisse zu vermeiden.
 </Callout>
 
+<Callout type="info">
+**`is_main_line` vs. `market=main`.** `is_main_line` wird pro `(event, market_type, selection)`-Kohorte ausgewertet: Es markiert die Hauptlinie *innerhalb der eigenen Linienstaffel jedes Markts*. Perioden- und Prop-Märkte liefern daher zu Recht Zeilen mit `is_main_line=true` (z. B. die Konsens-Halbzeit-Gesamtlinie); `?is_main_line=true` ist somit **kein** Filter, der nur die Hauptlinien des gesamten Spiels liefert. Um die Ergebnisse auf die **Hauptlinien des gesamten Spiels** zu beschränken (Moneyline, Spiel-Handicap, Spiel-Gesamtlinie), verwende stattdessen den Kategorie-Alias [`?market=main`](/de/api-reference/odds/#market-category-aliases), optional kombiniert mit `?is_main_line=true`, um zusätzlich die Alt-Linien innerhalb dieser Märkte auszuschließen.
+</Callout>
+
 ## Beispielanfragen
 
 <Tabs items={['cURL', 'JavaScript', 'Python']}>

--- a/content/de/api-reference/stream.mdx
+++ b/content/de/api-reference/stream.mdx
@@ -29,7 +29,7 @@ https://api.sharpapi.io/api/v1/stream?api_key=sk_live_your_key
 
 | Parameter | Typ | Standard | Beschreibung |
 |-----------|------|---------|-------------|
-| `channel` | string | `opportunities` | Was gestreamt werden soll: `odds`, `opportunities`, `gamestate` (nur Enterprise) oder `all` |
+| `channel` | string | `opportunities` | Was gestreamt werden soll: `odds`, `opportunities`, `gamestate` (nur Enterprise) oder `all`. Akzeptiert auch den Plural-Alias `channels`. Eine kommagetrennte Liste mit mehr als einem Kanal wird auf `all` reduziert — siehe Hinweis unten. |
 | `sport` | string | alle | Filter nach Sportart(en), kommagetrennt (z. B. `basketball`, `football`, `ice_hockey`) |
 | `sportsbook` | string | tariferlaubt | Filter nach Sportsbook(s), kommagetrennt |
 | `league` | string | alle | Filter nach Liga(en), kommagetrennt |
@@ -48,6 +48,10 @@ https://api.sharpapi.io/api/v1/stream?api_key=sk_live_your_key
 | `opportunities` | `snapshot`, `ev:detected/expired`, `arb:detected/expired`, `middles:detected/expired`, `low_hold:detected/expired`, `heartbeat` | Bei Opportunities benachrichtigen |
 | `gamestate` | `gamestate:snapshot`, `gamestate:update`, `gamestate:removed`, `heartbeat` | Live-Spielstände, Perioden, Uhren und situative Daten pro Event. **Nur Enterprise-Tarif.** Siehe [Live Game State](/api-reference/gamestate/) für den vollständigen Feldkatalog. |
 | `all` | Alle Event-Typen | Vollständiges Echtzeitbild |
+
+<Callout type="info">
+**Ein Abonnement pro SSE-Stream.** Aus Gründen der Parität mit der WebSocket-API akzeptiert der Endpoint sowohl `channel` als auch den Plural `channels`, und beide tolerieren einen kommagetrennten Wert. Eine SSE-Verbindung trägt jedoch ein **einziges** Abonnement: Wenn du mehr als einen gültigen Kanal übergibst (z. B. `?channels=odds,opportunities`), wird die Anfrage **auf `channel=all` reduziert**, statt einen Fehler zurückzugeben. Ein einzelner Wert (`?channel=odds`) streamt nur diesen Kanal. Um gezielt eine bestimmte *Teilmenge* von Kanälen zu abonnieren, verwende die [WebSocket-API](/streaming/websocket/), die echtes Multi-Channel-Filtern via `channels=` über eine einzige Verbindung unterstützt.
+</Callout>
 
 ### Komfort-Routen
 

--- a/content/de/concepts/live-vs-prematch.mdx
+++ b/content/de/concepts/live-vs-prematch.mdx
@@ -120,7 +120,7 @@ Wenn ein DK- oder FD-Markt ausgesetzt ist, verschwindet er einfach aus der API �
 | Pinnacle | Ja | Ausgezeichnet — tief, schnell, setzt selten aus | Sharp |
 | Bookmaker | Ja | Ausgezeichnet — breites Marktangebot, global | Sharp |
 | Circa Sports | Ja | Gut — Sharp-US-Buchmacher, fokussiertes Angebot | Sharp |
-| Bet365 | Ja | Gut — großes internationales Angebot | Pro |
+| Bet365 | Ja | Gut — großes internationales Angebot | Hobby |
 | BetMGM | Ja | Mittelmäßig — regelmäßige Aussetzungen | Hobby |
 | Caesars | Ja | Mittelmäßig — regelmäßige Aussetzungen | Hobby |
 | DraftKings | Ja | Begrenzt — häufige Aussetzungen, dünnes Angebot | Free |

--- a/content/en/api-reference/odds-best.mdx
+++ b/content/en/api-reference/odds-best.mdx
@@ -29,7 +29,7 @@ Best Odds is available on all tiers, including Free. The sportsbooks compared de
 | `market` | string | all | Filter by market type(s), comma-separated (e.g., `moneyline`, `spread`, `total`). Supports category aliases — see [Odds: Market Category Aliases](/en/api-reference/odds/#market-category-aliases). |
 | `event` | string | — | Filter by event ID(s), comma-separated |
 | `live` | boolean | — | `true` = live only, `false` = prematch only, omit = both |
-| `is_main_line` | boolean | — | `true` = main-line entries only (consensus line for each `(event, market, selection)` cohort plus no-line markets like moneyline); `false` = alt-line entries only; omit = both. See the `is_main_line` response field below for the cohort semantics. |
+| `is_main_line` | boolean | — | `true` = main-line entries only (consensus line for each `(event, market, selection)` cohort plus no-line markets like moneyline); `false` = alt-line entries only; omit = both. This is scoped **per market**, so period/prop markets keep their own main line — for full-game lines only, use `?market=main` (see note below). See the `is_main_line` response field below for the cohort semantics. |
 | `min_odds` | number | — | Minimum American odds filter |
 | `max_odds` | number | — | Maximum American odds filter |
 | `limit` | integer | 50 | Max results per page (max 200) |
@@ -37,6 +37,10 @@ Best Odds is available on all tiers, including Free. The sportsbooks compared de
 
 <Callout type="info">
 Stale odds (older than 5 minutes for pre-game, 1 minute for live) are automatically excluded from best-odds comparisons to prevent misleading results.
+</Callout>
+
+<Callout type="info">
+**`is_main_line` vs `market=main`.** `is_main_line` is evaluated per `(event, market_type, selection)` cohort — it marks the main line *within each market's own ladder*. Period and player-prop markets therefore legitimately return `is_main_line=true` rows (e.g. the consensus first-half total), so `?is_main_line=true` is **not** a "main game lines only" filter. To restrict results to **full-game core lines** (moneyline, full-game spread, full-game total), use the [`?market=main`](/en/api-reference/odds/#market-category-aliases) category alias instead — optionally combined with `?is_main_line=true` to also drop alt lines within those markets.
 </Callout>
 
 ## Example Requests

--- a/content/en/api-reference/stream.mdx
+++ b/content/en/api-reference/stream.mdx
@@ -29,7 +29,7 @@ https://api.sharpapi.io/api/v1/stream?api_key=sk_live_your_key
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `channel` | string | `opportunities` | What to stream: `odds`, `opportunities`, `gamestate` (Enterprise only), or `all` |
+| `channel` | string | `opportunities` | What to stream: `odds`, `opportunities`, `gamestate` (Enterprise only), or `all`. Also accepts the plural alias `channels`. A comma-separated list of more than one channel collapses to `all` — see the note below. |
 | `sport` | string | all | Filter by sport(s), comma-separated (e.g. `basketball`, `football`, `ice_hockey`) |
 | `sportsbook` | string | tier-allowed | Filter by sportsbook(s), comma-separated |
 | `league` | string | all | Filter by league(s), comma-separated |
@@ -48,6 +48,10 @@ https://api.sharpapi.io/api/v1/stream?api_key=sk_live_your_key
 | `opportunities` | `snapshot`, `ev:detected/expired`, `arb:detected/expired`, `middles:detected/expired`, `low_hold:detected/expired`, `heartbeat` | Alert on opportunities |
 | `gamestate` | `gamestate:snapshot`, `gamestate:update`, `gamestate:removed`, `heartbeat` | Live scores, periods, clocks, and situational data per event. **Enterprise tier only.** See [Live Game State](/api-reference/gamestate/) for the full field catalog. |
 | `all` | All event types | Full real-time picture |
+
+<Callout type="info">
+**One subscription per SSE stream.** For parity with the WebSocket API, the endpoint accepts both `channel` and the plural `channels`, and either one tolerates a comma-separated value. But an SSE connection carries a **single** subscription: if you pass more than one valid channel (e.g. `?channels=odds,opportunities`), the request **collapses to `channel=all`** instead of returning an error. A single value (`?channel=odds`) streams just that channel. To subscribe to a specific *subset* of channels selectively, use the [WebSocket API](/streaming/websocket/), which supports true multi-channel `channels=` filtering on one connection.
+</Callout>
 
 ### Convenience Routes
 

--- a/content/en/concepts/event-matching.mdx
+++ b/content/en/concepts/event-matching.mdx
@@ -89,6 +89,32 @@ Without the bucket, both fixtures would collide on one ID and odds would be mixe
 
 **What this means for cross-book matching.** Inside one fixture, every book that reports a start time within the same 6-hour window converges on the same `_b{N}`. Across a bucket boundary — for example, one book stamps a soccer kick-off at 17:55 UTC (`_b2`) and another at 18:10 UTC (`_b3`) — books can fragment across two canonical IDs. This is a known limitation. If you observe this, file a ticket with the event details.
 
+### Doubleheader suffix (`_g{N}`)
+
+When one book reports both games of a same-day doubleheader in a single update, the two fixtures are disambiguated with a trailing `_g{N}` suffix placed *after* the bucket — e.g. `mlb_athletics_mariners_2026-05-02_b0` and `mlb_athletics_mariners_2026-05-02_b0_g1`. Books that see only one of the two games emit the bare bucketed ID. The residual cross-book mismatch for doubleheaders is therefore: same `_b{N}` base, one side carrying a `_g{N}` suffix and the other not.
+
+### Grouping one matchup across IDs
+
+To collapse the rows that belong to a single physical fixture but landed on different canonical IDs, pick the level that matches your tolerance for merging:
+
+1. **Same-fixture collapse (recommended).** Strip a trailing `_g{N}` suffix and compare the remainder, keeping the `_b{N}` bucket intact:
+
+   ```
+   key = event_id with a trailing _g{N} removed     # ..._b0_g1 → ..._b0
+   group events whose stripped key is identical
+   ```
+
+   This reunites the doubleheader-suffix mismatch above without merging distinct games. It mirrors the server-side same-event predicate.
+
+2. **Loose matchup grouping (display).** To gather *every* price for a matchup on a date regardless of bucket — e.g. to render one card per game in a UI and absorb the cross-bucket-boundary fragmentation described above — strip **both** the `_g{N}` and `_b{N}` suffixes and group by `{league}_{teamA}_{teamB}_{date}`, tolerating ±1 day for starts that cross UTC midnight:
+
+   ```
+   key = "{league}_{teamA}_{teamB}_{date}"           # teams are already alpha-sorted; _b{N}/_g{N} dropped
+   group keys that share league + teams and whose dates are within 1 day of each other
+   ```
+
+   **Tradeoff:** because this discards the bucket, a genuine same-day doubleheader collapses into one group. Use level 1 when the two games must stay apart.
+
 ## Live vs Pre-Match Share The Same Event ID
 
 A given fixture has **one canonical event ID** that covers both pre-match and live (in-play) odds. The `is_live` field on each odds row tells you which state the price was collected in:

--- a/content/en/concepts/live-vs-prematch.mdx
+++ b/content/en/concepts/live-vs-prematch.mdx
@@ -120,7 +120,7 @@ When a DK or FD market is suspended, it simply disappears from the API — there
 | Pinnacle | Yes | Excellent — deep, fast, rarely suspends | Sharp |
 | Bookmaker | Yes | Excellent — wide market menu, global | Sharp |
 | Circa Sports | Yes | Good — sharp US book, focused menu | Sharp |
-| Bet365 | Yes | Good — large international menu | Pro |
+| Bet365 | Yes | Good — large international menu | Hobby |
 | BetMGM | Yes | Moderate — regular suspensions | Hobby |
 | Caesars | Yes | Moderate — regular suspensions | Hobby |
 | DraftKings | Yes | Limited — frequent suspensions, thin menu | Free |

--- a/content/es/api-reference/odds-best.mdx
+++ b/content/es/api-reference/odds-best.mdx
@@ -38,6 +38,10 @@ Best Odds está disponible en todos los planes, incluido el Free. Las casas de a
 Las cuotas obsoletas (con más de 5 minutos para prepartido, 1 minuto para en vivo) se excluyen automáticamente de las comparaciones de mejores cuotas para evitar resultados engañosos.
 </Callout>
 
+<Callout type="info">
+**`is_main_line` frente a `market=main`.** `is_main_line` se evalúa por cohorte `(event, market_type, selection)`: marca la línea principal *dentro del propio escalado de cada mercado*. Por eso los mercados de periodo y de props devuelven legítimamente filas con `is_main_line=true` (p. ej. el total consensuado de la primera mitad), de modo que `?is_main_line=true` **no** es un filtro de "solo líneas principales del partido completo". Para limitar los resultados a las **líneas principales del partido completo** (moneyline, hándicap de partido completo, total de partido completo), usa el alias de categoría [`?market=main`](/es/api-reference/odds/#market-category-aliases), opcionalmente combinado con `?is_main_line=true` para descartar además las líneas alternativas dentro de esos mercados.
+</Callout>
+
 ## Ejemplos de Solicitudes
 
 <Tabs items={['cURL', 'JavaScript', 'Python']}>

--- a/content/es/api-reference/stream.mdx
+++ b/content/es/api-reference/stream.mdx
@@ -29,7 +29,7 @@ https://api.sharpapi.io/api/v1/stream?api_key=sk_live_your_key
 
 | Parámetro | Tipo | Predeterminado | Descripción |
 |-----------|------|----------------|-------------|
-| `channel` | string | `opportunities` | Qué transmitir: `odds`, `opportunities`, `gamestate` (solo Enterprise) o `all` |
+| `channel` | string | `opportunities` | Qué transmitir: `odds`, `opportunities`, `gamestate` (solo Enterprise) o `all`. También acepta el alias plural `channels`. Una lista separada por comas con más de un canal colapsa a `all` — consulta la nota a continuación. |
 | `sport` | string | todos | Filtrar por deporte(s), separados por comas (p. ej. `basketball`, `football`, `ice_hockey`) |
 | `sportsbook` | string | permitidos por el plan | Filtrar por sportsbook(s), separados por comas |
 | `league` | string | todas | Filtrar por liga(s), separadas por comas |
@@ -48,6 +48,10 @@ https://api.sharpapi.io/api/v1/stream?api_key=sk_live_your_key
 | `opportunities` | `snapshot`, `ev:detected/expired`, `arb:detected/expired`, `middles:detected/expired`, `low_hold:detected/expired`, `heartbeat` | Alertas sobre oportunidades |
 | `gamestate` | `gamestate:snapshot`, `gamestate:update`, `gamestate:removed`, `heartbeat` | Marcadores en vivo, periodos, relojes y datos situacionales por evento. **Solo plan Enterprise.** Consulta [Estado del juego en vivo](/api-reference/gamestate/) para el catálogo completo de campos. |
 | `all` | Todos los tipos de eventos | Imagen completa en tiempo real |
+
+<Callout type="info">
+**Una suscripción por stream SSE.** Por paridad con la API WebSocket, el endpoint acepta tanto `channel` como el plural `channels`, y ambos toleran un valor separado por comas. Pero una conexión SSE mantiene una **única** suscripción: si pasas más de un canal válido (p. ej. `?channels=odds,opportunities`), la solicitud **colapsa a `channel=all`** en lugar de devolver un error. Un único valor (`?channel=odds`) transmite solo ese canal. Para suscribirte de forma selectiva a un *subconjunto* concreto de canales, usa la [API WebSocket](/streaming/websocket/), que admite el filtrado multicanal real con `channels=` en una sola conexión.
+</Callout>
 
 ### Rutas de conveniencia
 

--- a/content/es/concepts/live-vs-prematch.mdx
+++ b/content/es/concepts/live-vs-prematch.mdx
@@ -120,7 +120,7 @@ Cuando un mercado de DK o FD está suspendido, simplemente desaparece de la API:
 | Pinnacle | Sí | Excelente: profundo, rápido, rara vez suspende | Sharp |
 | Bookmaker | Sí | Excelente: amplio menú de mercados, global | Sharp |
 | Circa Sports | Sí | Bueno: casa profesional estadounidense, menú enfocado | Sharp |
-| Bet365 | Sí | Bueno: amplio menú internacional | Pro |
+| Bet365 | Sí | Bueno: amplio menú internacional | Hobby |
 | BetMGM | Sí | Moderado: suspensiones regulares | Hobby |
 | Caesars | Sí | Moderado: suspensiones regulares | Hobby |
 | DraftKings | Sí | Limitado: suspensiones frecuentes, menú reducido | Free |

--- a/content/pt-BR/api-reference/odds-best.mdx
+++ b/content/pt-BR/api-reference/odds-best.mdx
@@ -38,6 +38,10 @@ Best Odds está disponível em todos os planos, incluindo o Free. As casas de ap
 Odds desatualizadas (mais de 5 minutos para pré-jogo, 1 minuto para ao vivo) são excluídas automaticamente das comparações de melhores odds para evitar resultados enganosos.
 </Callout>
 
+<Callout type="info">
+**`is_main_line` vs. `market=main`.** `is_main_line` é avaliado por coorte `(event, market_type, selection)`: marca a linha principal *dentro do próprio leque de cada mercado*. Por isso mercados de período e de props retornam legitimamente linhas com `is_main_line=true` (ex.: o total de consenso do primeiro tempo), de forma que `?is_main_line=true` **não** é um filtro de "apenas linhas principais do jogo completo". Para restringir os resultados às **linhas principais do jogo completo** (moneyline, handicap de jogo completo, total de jogo completo), use o alias de categoria [`?market=main`](/pt-BR/api-reference/odds/#market-category-aliases), opcionalmente combinado com `?is_main_line=true` para também descartar as linhas alternativas dentro desses mercados.
+</Callout>
+
 ## Exemplos de Requisição
 
 <Tabs items={['cURL', 'JavaScript', 'Python']}>

--- a/content/pt-BR/api-reference/stream.mdx
+++ b/content/pt-BR/api-reference/stream.mdx
@@ -29,7 +29,7 @@ https://api.sharpapi.io/api/v1/stream?api_key=sk_live_your_key
 
 | Parâmetro | Tipo | Padrão | Descrição |
 |-----------|------|---------|-------------|
-| `channel` | string | `opportunities` | O que transmitir: `odds`, `opportunities`, `gamestate` (apenas Enterprise) ou `all` |
+| `channel` | string | `opportunities` | O que transmitir: `odds`, `opportunities`, `gamestate` (apenas Enterprise) ou `all`. Também aceita o alias plural `channels`. Uma lista separada por vírgulas com mais de um canal colapsa para `all` — veja a nota abaixo. |
 | `sport` | string | todos | Filtrar por esporte(s), separados por vírgula (ex.: `basketball`, `football`, `ice_hockey`) |
 | `sportsbook` | string | permitidos pelo plano | Filtrar por sportsbook(s), separados por vírgula |
 | `league` | string | todas | Filtrar por liga(s), separadas por vírgula |
@@ -48,6 +48,10 @@ https://api.sharpapi.io/api/v1/stream?api_key=sk_live_your_key
 | `opportunities` | `snapshot`, `ev:detected/expired`, `arb:detected/expired`, `middles:detected/expired`, `low_hold:detected/expired`, `heartbeat` | Alertar sobre oportunidades |
 | `gamestate` | `gamestate:snapshot`, `gamestate:update`, `gamestate:removed`, `heartbeat` | Placares ao vivo, períodos, cronômetros e dados situacionais por evento. **Apenas plano Enterprise.** Veja [Live Game State](/api-reference/gamestate/) para o catálogo completo de campos. |
 | `all` | Todos os tipos de evento | Visão completa em tempo real |
+
+<Callout type="info">
+**Uma assinatura por stream SSE.** Para manter paridade com a API WebSocket, o endpoint aceita tanto `channel` quanto o plural `channels`, e ambos toleram um valor separado por vírgulas. Mas uma conexão SSE mantém uma **única** assinatura: se você passar mais de um canal válido (ex.: `?channels=odds,opportunities`), a requisição **colapsa para `channel=all`** em vez de retornar um erro. Um único valor (`?channel=odds`) transmite apenas aquele canal. Para assinar de forma seletiva um *subconjunto* específico de canais, use a [API WebSocket](/streaming/websocket/), que oferece filtragem multicanal real com `channels=` em uma única conexão.
+</Callout>
 
 ### Rotas de Conveniência
 

--- a/content/pt-BR/concepts/live-vs-prematch.mdx
+++ b/content/pt-BR/concepts/live-vs-prematch.mdx
@@ -120,7 +120,7 @@ Quando um mercado da DK ou FD é suspenso, ele simplesmente desaparece da API �
 | Pinnacle | Sim | Excelente — profunda, rápida, raramente suspende | Sharp |
 | Bookmaker | Sim | Excelente — cardápio amplo de mercados, global | Sharp |
 | Circa Sports | Sim | Boa — casa sharp dos EUA, cardápio focado | Sharp |
-| Bet365 | Sim | Boa — grande cardápio internacional | Pro |
+| Bet365 | Sim | Boa — grande cardápio internacional | Hobby |
 | BetMGM | Sim | Moderada — suspensões regulares | Hobby |
 | Caesars | Sim | Moderada — suspensões regulares | Hobby |
 | DraftKings | Sim | Limitada — suspensões frequentes, cardápio enxuto | Free |


### PR DESCRIPTION
## What

Closes the four documentation gaps from the Crisp **c8594804** diligence audit (engineering verdicts in `Mlaz-code/sharp-api-go#885`). Each fix was verified against current code, not just the issue text.

| # | Gap | Code truth | Fix |
|---|-----|-----------|-----|
| 1 | `live-vs-prematch.mdx` tier table lists **Bet365 = Pro** | `RequiresTier: "hobby"` (`sharp-api-go/sportsbooks.go:33-34`); `api-reference/sportsbooks.mdx` already says Hobby | Bet365 → **Hobby** (all 4 locales) |
| 2 | `stream.mdx` documents `channel` as a single value only | `sse.go:253-271` accepts `channel`/`channels` as CSV; **>1 valid channel collapses to `all`**; WS does true selective multi-channel | Documented the `channels` alias + collapse-to-`all`, with a callout contrasting the WS API (all 4 locales) |
| 3 | `/odds/best` — `is_main_line` reads like a "main game lines only" filter | `is_main_line` is per-`(event, market_type, selection)` cohort, so period/prop mains legitimately carry `is_main_line=true`; `?market=main` is the full-game filter (`main.go:7721-7730`) | Added a callout spelling out `is_main_line` vs `?market=main` (all 4 locales) |
| 4 | `event-matching.mdx` documents the `_bN` bucket but gives no cross-bucket **grouping recipe** | `strip_doubleheader_suffix` / `same_event` strip `_g{N}` and keep `_b{N}`; bucket deliberately separates doubleheaders (`api-adapters/utils/canonical_ids.py:531-559`) | Added the `_g{N}` doubleheader suffix + a **two-level grouping recipe** (safe same-fixture collapse vs. loose display grouping, with the doubleheader tradeoff stated) |

## Why the recipe has two levels (item 4)

The issue suggested a single recipe — strip `_b{N}`/`_g{N}` and group by `{league}_{teams}_{date}`. But the `_b{N}` bucket exists precisely to keep same-day doubleheaders and cross-midnight rematches apart, so blindly stripping it **re-merges genuine doubleheaders**. The doc now gives both levels and states the tradeoff honestly:

1. **Same-fixture collapse (recommended)** — strip only `_g{N}`, keep `_b{N}` (mirrors the server-side `same_event` predicate).
2. **Loose matchup grouping (display)** — also strip `_b{N}`, group by `{league}_{teamA}_{teamB}_{date}`, ±1 day; note that this collapses real doubleheaders.

## Scope note (i18n)

Item 4 is **English-only**: the `de` / `es` / `pt-BR` `event-matching.mdx` pages predate the SHA-3432 `_bN` documentation entirely (they still show the old `nba_celtics_lakers_20260208` date format and have no bucket section), so a grouping recipe has no coherent place to attach there. Items 1–3 are applied across all four locales. **Follow-up:** backfill the full `_bN` bucket section into the three translated `event-matching.mdx` pages.

## Verification

- `npm run build` (full pipeline — `next build` across all 4 locales, 224 pages) passes; pagefind indexes cleanly.
- All `<Callout>` tags balanced; new code fences render inside the numbered list.

Fixes #265

Type: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
